### PR TITLE
Added  Helm Chart to install Windows Exporter 

### DIFF
--- a/windows-exporter/.helmignore
+++ b/windows-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/windows-exporter/Chart.yaml
+++ b/windows-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: windows-exporter
+description: A Helm chart to deploy windows-exporter and register to prometheus via podmonitor in a k8s cluster
+version: 0.1.0
+appVersion: "1.0.0"

--- a/windows-exporter/README.md
+++ b/windows-exporter/README.md
@@ -17,7 +17,7 @@ The following table lists the values accepted by the chart
 
 | Key               | Description                                                                                                                 | Default |
 |-------------------| ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `fullname`        | Fullname of the PodMonitor to be created       | `windows-exporter-podmonitor`  |
+| `fullname`        | Fullname of the PodMonitor to be created       | `windows-exporter`  |
 | `jobLabel`      | The label of the job this PodMonitor targets               | `windows-exporter`  |
 | `labels` | Labels to add to the PodMonitor      | `app: windows-exporter`<br>`release: prometheus-operator`  |
 | `selectorLabels` | Labels used to select pods      | `app: windows-exporter`  |
@@ -26,7 +26,7 @@ The following table lists the values accepted by the chart
 
 | Key               | Description                                                                                                                 | Default |
 |-------------------| ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `fullname`        | Fullname of the DaemonSet to be created       | `windows-exporter-daemonset`  |
+| `fullname`        | Fullname of the DaemonSet to be created       | `windows-exporter`  |
 | `hostPort`      | The host port to bind for the metrics endpoint               | `9182`  |
 | `metricsPortname` | Name of the port where metrics are exposed on the pods      | `http-web`  |
 | `labels` | Labels to add to the DaemonSet      | `app: windows-exporter`  |

--- a/windows-exporter/README.md
+++ b/windows-exporter/README.md
@@ -1,0 +1,52 @@
+# Windows Exporter DaemonSet and Pod Monitor Helm Chart
+
+A Helm chart to deploy a DaemonSet and Pod Monitor for Windows nodes.
+
+## Values
+
+The following table lists the values accepted by the chart
+
+| Key                | Description                                                                                                                           | Default               |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------| --------------------- |
+| `namespace` | The namespace to deploy the chart | `default`                  |
+| `podMonitor` | Map of objects to configure a PodMonitor. The key of the map should be the name of the configurations to be used and the value should be the desired value for the PodMonitor to run | `{}` |
+| `windowsExporter` | Map of objects to configure the Windows Exporter DaemonSet. The key of the map should be the name of the configurations to be used and the value should be the desired value for the DaemonSet to run | `{}` |
+| `configMap` | Map of objects to configure the ConfigMap. The key of the map should be the name of the configurations to be used and the value should be the desired value for the ConfigMap to run | `{}` |
+
+## PodMonitor Configurations
+
+| Key               | Description                                                                                                                 | Default |
+|-------------------| ---------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `fullname`        | Fullname of the PodMonitor to be created       | `windows-exporter-podmonitor`  |
+| `jobLabel`      | The label of the job this PodMonitor targets               | `windows-exporter`  |
+| `labels` | Labels to add to the PodMonitor      | `app: windows-exporter`<br>`release: prometheus-operator`  |
+| `selectorLabels` | Labels used to select pods      | `app: windows-exporter`  |
+
+## Windows Exporter DaemonSet Configurations
+
+| Key               | Description                                                                                                                 | Default |
+|-------------------| ---------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `fullname`        | Fullname of the DaemonSet to be created       | `windows-exporter-daemonset`  |
+| `hostPort`      | The host port to bind for the metrics endpoint               | `9182`  |
+| `metricsPortname` | Name of the port where metrics are exposed on the pods      | `http-web`  |
+| `labels` | Labels to add to the DaemonSet      | `app: windows-exporter`  |
+| `selectorLabels` | Labels used to select pods      | `app: windows-exporter`  |
+| `nodeSelector` | Node selector to use to select nodes where the DaemonSet runs      | `kubernetes.io/os: windows`  |
+| `tolerations` | Tolerations to add to the DaemonSet      | `- effect: NoSchedule`<br>`  key: kubernetes.azure.com/scalesetpriority`<br>`  operator: Equal`<br>`  value: spot`<br>`- effect: NoSchedule`<br>`  key: dedicated`<br>`  operator: Equal`<br>`  value: windowsnode`  |
+
+## ConfigMap Configurations
+
+| Key               | Description                                                                                                                 | Default |
+|-------------------| ---------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `configMapName`        | Name of the ConfigMap to be created       | `windows-exporter-config`  |
+| `config`      | Configuration data to add to the ConfigMap               | `collectors: enabled: '[defaults],container'`<br>`collector:`<br>`  service:`<br>`    services-where: "Name='containerd' or Name='kubelet'"`  |
+
+## Usage
+
+```bash
+helm repo add facets-cloud https://facets-cloud.github.io/helm-charts
+
+helm install [RELEASE_NAME] facets-cloud/windows-exporter -f [VALUES_FILE]
+```
+
+

--- a/windows-exporter/templates/configmap.yaml
+++ b/windows-exporter/templates/configmap.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Values.windowsExporter.configMapName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.windowsExporter.fullname }}
+data:
+  config.yml: |
+{{- toYaml .Values.windowsExporter.config | nindent 4 }}

--- a/windows-exporter/templates/configmap.yaml
+++ b/windows-exporter/templates/configmap.yaml
@@ -1,10 +1,12 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .Values.windowsExporter.configMapName }}
+  name: {{ .Values.configMap.configMapName }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: {{ .Values.windowsExporter.fullname }}
+    {{- range $key, $value := .Values.windowsExporter.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 data:
   config.yml: |
-{{- toYaml .Values.windowsExporter.config | nindent 4 }}
+{{- toYaml .Values.configMap.config | nindent 4 }}

--- a/windows-exporter/templates/daemonset.yaml
+++ b/windows-exporter/templates/daemonset.yaml
@@ -1,9 +1,12 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: {{ .Values.namespace }}
   name: {{ .Values.windowsExporter.fullname }}
+  namespace: {{ .Values.namespace }}
   labels:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9182"
+    prometheus.io/path: "metrics"
     {{- range $key, $value := .Values.windowsExporter.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -20,8 +23,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+      securityContext: 
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
       hostNetwork: true
       initContainers:
         - name: configure-firewall
@@ -31,12 +36,12 @@ spec:
       containers:
       - args: 
         - --config.file=./config.yml
-        name: {{ .Chart.Name }}
-        image: {{ .Values.windowsExporter.image.repository }}:{{ .Values.windowsExporter.image.tag }}
-        imagePullPolicy: {{ .Values.windowsExporter.image.pullPolicy }}
+        name: windows-exporter
+        image: ghcr.io/prometheus-community/windows-exporter:latest-1809
+        imagePullPolicy: Always
         ports:
-        - containerPort: {{ .Values.windowsExporter.metricsPort }}
-          hostPort: {{ .Values.windowsExporter.metricsPort }}
+        - containerPort: 9182
+          hostPort: {{ .Values.windowsExporter.hostPort }}
           name: {{ .Values.windowsExporter.metricsPortname }}
         volumeMounts:
         - name: windows-exporter-config
@@ -53,4 +58,4 @@ spec:
       volumes:
       - name: windows-exporter-config
         configMap:
-          name: {{ .Values.windowsExporter.configMapName }}
+          name: {{ .Values.configMap.configMapName }}

--- a/windows-exporter/templates/daemonset.yaml
+++ b/windows-exporter/templates/daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: {{ .Values.namespace }}
+  name: {{ .Values.windowsExporter.fullname }}
+  labels:
+    {{- range $key, $value := .Values.windowsExporter.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- range $key, $value := .Values.windowsExporter.selectorLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.windowsExporter.selectorLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      hostNetwork: true
+      initContainers:
+        - name: configure-firewall
+          image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+          command: ["powershell"]
+          args: ["-c", "New-NetFirewallRule", "-DisplayName", "'windows-exporter'", "-Direction", "inbound", "-Profile", "Any", "-Action", "Allow", "-LocalPort", "9182", "-Protocol", "TCP"]  
+      containers:
+      - args: 
+        - --config.file=./config.yml
+        name: {{ .Chart.Name }}
+        image: {{ .Values.windowsExporter.image.repository }}:{{ .Values.windowsExporter.image.tag }}
+        imagePullPolicy: {{ .Values.windowsExporter.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.windowsExporter.metricsPort }}
+          hostPort: {{ .Values.windowsExporter.metricsPort }}
+          name: {{ .Values.windowsExporter.metricsPortname }}
+        volumeMounts:
+        - name: windows-exporter-config
+          mountPath: .\config.yml
+          subPath: config.yml
+      {{- with .Values.windowsExporter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.windowsExporter.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: windows-exporter-config
+        configMap:
+          name: {{ .Values.windowsExporter.configMapName }}

--- a/windows-exporter/templates/podmonitor.yaml
+++ b/windows-exporter/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.podMonitor.fullname }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- range $key, $value := .Values.podMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  jobLabel: windows-exporter
+  selector:
+    matchLabels:
+      {{- range $key, $value := .Values.podMonitor.selectorLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+  podMetricsEndpoints:
+  - port: {{ .Values.podMonitor.metricsPort }}
+    scheme: {{ .Values.podMonitor.scheme }}
+

--- a/windows-exporter/templates/podmonitor.yaml
+++ b/windows-exporter/templates/podmonitor.yaml
@@ -18,3 +18,4 @@ spec:
   - port: {{ .Values.windowsExporter.metricsPortname }}
     scheme: http
 
+

--- a/windows-exporter/templates/podmonitor.yaml
+++ b/windows-exporter/templates/podmonitor.yaml
@@ -8,13 +8,13 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  jobLabel: windows-exporter
+  jobLabel: {{ .Values.podMonitor.jobLabel }}
   selector:
     matchLabels:
       {{- range $key, $value := .Values.podMonitor.selectorLabels }}
       {{ $key }}: {{ $value | quote }}
       {{- end }}
   podMetricsEndpoints:
-  - port: {{ .Values.podMonitor.metricsPort }}
-    scheme: {{ .Values.podMonitor.scheme }}
+  - port: {{ .Values.windowsExporter.metricsPortname }}
+    scheme: http
 

--- a/windows-exporter/values.yaml
+++ b/windows-exporter/values.yaml
@@ -1,7 +1,7 @@
 namespace: default
 
 podMonitor:
-  fullname: windows-exporter-podmonitor
+  fullname: windows-exporter
   jobLabel: windows-exporter
   labels:
     app: windows-exporter
@@ -10,7 +10,7 @@ podMonitor:
     app: windows-exporter
 
 windowsExporter:
-  fullname: windows-exporter-daemonset
+  fullname: windows-exporter
   hostPort: 9182
   metricsPortname: http-web
   labels:

--- a/windows-exporter/values.yaml
+++ b/windows-exporter/values.yaml
@@ -1,14 +1,8 @@
-securityContext: 
-  windowsOptions:
-    hostProcess: true
-    runAsUserName: "NT AUTHORITY\\system"
-
 namespace: default
 
 podMonitor:
   fullname: windows-exporter-podmonitor
-  metricsPort: http-web
-  scheme: http
+  jobLabel: windows-exporter
   labels:
     app: windows-exporter
     release: prometheus-operator
@@ -16,22 +10,13 @@ podMonitor:
     app: windows-exporter
 
 windowsExporter:
-  fullname: windows-exporter
-  metricsPort: 9182
+  fullname: windows-exporter-daemonset
+  hostPort: 9182
   metricsPortname: http-web
-  scheme: http
   labels:
     app: windows-exporter
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9182"
-    prometheus.io/path: "metrics"
   selectorLabels:
     app: windows-exporter
-  image:
-    repository: ghcr.io/prometheus-community/windows-exporter
-    pullPolicy: Always
-    tag: latest-1809
-  configMapName: windows-exporter-config
   nodeSelector:
     kubernetes.io/os: windows
   tolerations:
@@ -44,6 +29,7 @@ windowsExporter:
       operator: Equal
       value: windowsnode
 
+configMap:
   configMapName: windows-exporter-config
   config:
     collectors:

--- a/windows-exporter/values.yaml
+++ b/windows-exporter/values.yaml
@@ -1,0 +1,53 @@
+securityContext: 
+  windowsOptions:
+    hostProcess: true
+    runAsUserName: "NT AUTHORITY\\system"
+
+namespace: default
+
+podMonitor:
+  fullname: windows-exporter-podmonitor
+  metricsPort: http-web
+  scheme: http
+  labels:
+    app: windows-exporter
+    release: prometheus-operator
+  selectorLabels:
+    app: windows-exporter
+
+windowsExporter:
+  fullname: windows-exporter
+  metricsPort: 9182
+  metricsPortname: http-web
+  scheme: http
+  labels:
+    app: windows-exporter
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9182"
+    prometheus.io/path: "metrics"
+  selectorLabels:
+    app: windows-exporter
+  image:
+    repository: ghcr.io/prometheus-community/windows-exporter
+    pullPolicy: Always
+    tag: latest-1809
+  configMapName: windows-exporter-config
+  nodeSelector:
+    kubernetes.io/os: windows
+  tolerations:
+    - effect: NoSchedule
+      key: kubernetes.azure.com/scalesetpriority
+      operator: Equal
+      value: spot
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
+      value: windowsnode
+
+  configMapName: windows-exporter-config
+  config:
+    collectors:
+      enabled: '[defaults],container'
+    collector:
+      service:
+        services-where: "Name='containerd' or Name='kubelet'"


### PR DESCRIPTION
helm chart contains templates
- daemonsets.yaml : launches windows-exporter pods into the k8s cluster
- podmonitor.yaml : creates podMonitor resource, that'll add windows-exporter to Prometheus scrape-config
- configmap.yaml :  setups config file required by windows-exporter daemonsets

Values can be overridden using values.yaml file, instructions -> README.md