### PR TITLE
Added a new image pull secret to handle legacy

### DIFF
--- a/azure-nfs-log-collector/templates/compress-logs.yaml
+++ b/azure-nfs-log-collector/templates/compress-logs.yaml
@@ -29,11 +29,26 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - find /var/log/efs -type f -name "*.log" -mtime +$COMPRESS_LOGS_BEFORE_DAYS
-                  -exec sh -c 'pod=$(basename "${1%/*.*}"); day=$(date -r "$1" +%Y%m%d);
-                  zip_file="${1%/*}/${pod}_${day}.zip"; [ -f "$zip_file" ] && cmd="zip
-                  -j -u $zip_file $1" || cmd="zip -j $zip_file $1"; $cmd; rm "$1"' _ {}
-                  \;
+                - |
+                  LOG_PATH="/var/log/efs"
+                  total_uncompressed=$(find "$LOG_PATH" -type f -name '*.log' -mtime +$COMPRESS_LOGS_BEFORE_DAYS | wc -l)
+                  echo "Total .log files to be compressed before $COMPRESS_LOGS_BEFORE_DAYS days: $total_uncompressed"
+                  while [ "$total_uncompressed" -gt 0 ]; do
+                      echo "Compressing $total_uncompressed files..."
+                      uncompressed_files=$(find "$LOG_PATH" -type f -name "*.log" -mtime +$COMPRESS_LOGS_BEFORE_DAYS)
+                      echo "$uncompressed_files" | xargs -I {} sh -c '
+                            pod=$(basename "${1%/*.*}")
+                            day=$(date -r "$1" +%Y%m%d)
+                            zip_file="${1%/*}/${pod}_${day}.zip"
+                            [ -f "$zip_file" ] && cmd="zip -j -u $zip_file $1" || cmd="zip -j $zip_file $1"
+                            $cmd
+                            rm "$1"
+                            ' _ {}
+                      remaining_uncompressed_files=$(find "$LOG_PATH" -type f -name '*.log' -mtime +$COMPRESS_LOGS_BEFORE_DAYS | wc -l)
+                      echo "$remaining_uncompressed_files files remains to be compressed out of $total_uncompressed"
+                      total_uncompressed=$remaining_uncompressed_files
+                  done
+                  echo "All files compressed."
               image: {{ .Values.compressLogs.image }}
               imagePullPolicy: {{ .Values.compressLogs.imagePullPolicy }}
               name: compress-logs


### PR DESCRIPTION
#Testing 
### local testing 
<img width="1016" alt="image" src="https://github.com/Facets-cloud/helm-charts/assets/111746197/21dc54f8-1923-43b3-8024-200732c74752">
- Yaml config 
<img width="911" alt="image" src="https://github.com/Facets-cloud/helm-charts/assets/111746197/e32822b1-8116-46d4-8638-1ddc30f9bcb8">

- ASI-UAT testing and result. 
<img width="756" alt="image" src="https://github.com/Facets-cloud/helm-charts/assets/111746197/7e0633c1-4bfa-4d70-b460-e6d6d39f9b0a">
 
