### PR TITLE
added tolerations for deploy-scaler

### DIFF
--- a/scheduled-deployment-scaler/templates/scheduled-scaler-crons.yaml
+++ b/scheduled-deployment-scaler/templates/scheduled-scaler-crons.yaml
@@ -20,6 +20,10 @@ spec:
               image: bitnami/kubectl:1.21
               command: ["/bin/sh", "-c", "kubectl scale --replicas={{ $schedule.desiredReplicas }} deployment {{ $schedule.deployment }} -n {{ default $schedule.namespace "default" }}"]
           restartPolicy: OnFailure
+          {{- with $.Values.tolerations }}
+          tolerations:
+            {{ . | toYaml | nindent 10 }}
+          {{- end }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/scheduled-deployment-scaler/values.yaml
+++ b/scheduled-deployment-scaler/values.yaml
@@ -1,1 +1,2 @@
 scalingSchedules: {}
+tolerations: []


### PR DESCRIPTION
While using it, found missing toleration causing cronjob pods to be in the pending state as the node pool had taints.