### PR TITLE
Feature: Added support for image, nodeSelector

### DIFF
--- a/kubectl-crons/README.md
+++ b/kubectl-crons/README.md
@@ -10,6 +10,8 @@ The following table lists the values accepted by the chart
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------| --------------------- |
 | `cronConfig` | Map of objects. The key of the map should be the name of the configurations to be used and the value should be the desired value for the cronjob to run | `{}`                  |
 | `tolerations` | The tolerations to be added to the pod created by cronjob     | `null`  |
+| `nodeSelector` | The nodeSelector to be added to the pod created by cronjob     | `null`  |
+| `image` | The container image for the cronjob     | `bitnami/kubectl:1.16`  |
 
 ## Cronjob Configurations
 
@@ -41,7 +43,10 @@ tolerations:
   - key: kubernetes.azure.com/scalesetpriority
     operator: "Equal"
     value: spot
-    effect: "NoSchedule" 
+    effect: "NoSchedule"
 
+nodeSelector:
+  kubernetes.io/os: linux
 
+image: "bitnami/kubectl:1.16"
 ```

--- a/kubectl-crons/templates/cronjob.yaml
+++ b/kubectl-crons/templates/cronjob.yaml
@@ -25,11 +25,15 @@ spec:
           serviceAccountName: {{ $.Release.Name }}
           {{- with $.Values.tolerations }}
           tolerations:
-            {{ . | toYaml | nindent 10 }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
+          {{- with $.Values.nodeSelector }}
+          nodeSelector:
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           containers:
             - name: {{ $.Release.Name }}
-              image: "bitnami/kubectl:1.16"
+              image: {{ $.Values.image | quote }}
               command: 
               - "sh"
               - "-c"

--- a/kubectl-crons/values.yaml
+++ b/kubectl-crons/values.yaml
@@ -9,8 +9,11 @@ cronConfig:
 - cronName: "cleanup-completed-pods"
   schedule: "0 0 * * *"
   command: "kubectl get pod --field-selector=status.phase='Failed'| grep -E 'Completed' | awk '{print $1}' | xargs -r kubectl delete pod -n default"
+image: "bitnami/kubectl:1.16"
 # tolerations: 
 #   - key: "example-key"
 #     operator: "Equal"
 #     value: "example-value"
-#     effect: "NoSchedule"  
+#     effect: "NoSchedule"
+# nodeSelector:
+#   kubernetes.io/os: linux


### PR DESCRIPTION
# Test
Below is the generated template 

```yaml
❯ helm template .  --debug
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /Users/pramodhayyappan/dev/work/repos/helm-charts/kubectl-crons

---
# Source: kubectl-crons/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name
  namespace: default
---
# Source: kubectl-crons/templates/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: release-name
rules:
- apiGroups:
    - ""
  resources:
    - pods
  verbs:
    - get
    - list
    - watch
    - delete
---
# Source: kubectl-crons/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name
roleRef:
  kind: ClusterRole
  name: release-name
  apiGroup: rbac.authorization.k8s.io
subjects:
- kind: ServiceAccount
  name: release-name
  namespace: default
---
# Source: kubectl-crons/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: release-name-cleanup-terminated-pods
  labels:
    app: cronjob-cleanup-terminated-pods
    release: cronjob-cleanup-terminated-pods
spec:
  suspend: false
  concurrencyPolicy: Forbid
  schedule: "0 0 * * *"
  successfulJobsHistoryLimit: 10
  failedJobsHistoryLimit: 10
  jobTemplate:
    spec:
      backoffLimit: 0
      template:
        metadata:
          labels:
            app: cronjob-cleanup-terminated-pods
            release: cronjob-cleanup-terminated-pods
        spec:
          restartPolicy: Never
          serviceAccountName: release-name
          tolerations:
          - effect: NoSchedule
            key: example-key
            operator: Equal
            value: example-value
          nodeSelector:
            kubernetes.io/os: linux
          containers:
            - name: release-name
              image: "bitnami/kubectl:1.16"
              command:
              - "sh"
              - "-c"
              - "kubectl get pod --field-selector=status.phase='Failed'| grep -E 'NodeShutdown|Terminated' | awk '{print $1}' | xargs -r kubectl delete pod -n default"
---
# Source: kubectl-crons/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: release-name-cleanup-completed-pods
  labels:
    app: cronjob-cleanup-completed-pods
    release: cronjob-cleanup-completed-pods
spec:
  suspend: false
  concurrencyPolicy: Forbid
  schedule: "0 0 * * *"
  successfulJobsHistoryLimit: 10
  failedJobsHistoryLimit: 10
  jobTemplate:
    spec:
      backoffLimit: 0
      template:
        metadata:
          labels:
            app: cronjob-cleanup-completed-pods
            release: cronjob-cleanup-completed-pods
        spec:
          restartPolicy: Never
          serviceAccountName: release-name
          tolerations:
          - effect: NoSchedule
            key: example-key
            operator: Equal
            value: example-value
          nodeSelector:
            kubernetes.io/os: linux
          containers:
            - name: release-name
              image: "bitnami/kubectl:1.16"
              command:
              - "sh"
              - "-c"
              - "kubectl get pod --field-selector=status.phase='Failed'| grep -E 'Completed' | awk '{print $1}' | xargs -r kubectl delete pod -n default"
```