### PR TITLE
[S74] Feature: GA to version control the charts

### DIFF
--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_dir: charts
+          publish_dir: ./charts
           keep_files: true
           force_orphan: false
           deploy_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Package and publish chart
         run: |
           for dir in */; do
-            if [[ "$dir" != .* ]]; then
+            if [[ "$dir" != .* ]] && [[ "$dir" != "charts/" ]] && [[ -f "$dir/Chart.yaml" ]]; then
               helm package "$dir"
             fi
           done

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -3,39 +3,45 @@ name: Package and Publish Helm Chart
 on:
   workflow_dispatch:
 
-env:
-  BRANCH: gh-pages
-
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+      
+      - name: Checkout gh-pages branch code
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: tmp/charts
+      
       - name: Set up Helm
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl
-          curl https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz | tar xz
+          sudo apt-get install -y curl tar
+          curl -sSL https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz | tar xz
           sudo mv linux-amd64/helm /usr/local/bin/helm
+      
+      - name: Get previous build charts
+        run: |
+          mkdir -p charts
+          cp tmp/charts/*.tgz charts
 
       - name: Package and publish chart
         run: |
           for dir in */; do
-            if [[ "$dir" != .* ]] && [[ "$dir" != "charts/" ]] && [[ -f "$dir/Chart.yaml" ]]; then
+            if [[ -d "$dir" ]] && [[ -f "$dir/Chart.yaml" ]]; then
               helm package "$dir"
             fi
           done
-          mkdir -p charts
           mv *.tgz charts/
           helm repo index charts/
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_dir: ./charts
-          keep_files: true
+          publish_dir: charts
+          keep_files: false
           force_orphan: false
           deploy_key: ${{ secrets.DEPLOY_KEY }}
-          branch: ${{ env.BRANCH }}

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -32,6 +32,7 @@ jobs:
           helm repo index charts/
       
       - name: Commit and push changes
+        if: github.ref == 'refs/heads/master'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -13,25 +13,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Package and publish chart
+      - name: Set up Helm
         run: |
           sudo apt-get update
           sudo apt-get install -y curl
           curl https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz | tar xz
-          ./linux-amd64/helm package kubectl-crons
-          ./linux-amd64/helm package scheduled-deployment-scaler
-          ./linux-amd64/helm package windows-exporter
-          ./linux-amd64/helm package facets-notification-controller
-          ./linux-amd64/helm package azure-nfs-log-collector
-          ./linux-amd64/helm package database-operator
-          ./linux-amd64/helm package scheduled-hpa-updater
-          ./linux-amd64/helm package facets-uptime-monitoring
-          ./linux-amd64/helm package secret-copier
-          ./linux-amd64/helm package kube-audit-rest
-          ./linux-amd64/helm package mongodb-auth-operator
+          sudo mv linux-amd64/helm /usr/local/bin/helm
+
+      - name: Package and publish chart
+        run: |
+          for dir in */; do
+            if [[ "$dir" != .* ]]; then
+              helm package "$dir"
+            fi
+          done
           mkdir -p charts
           mv *.tgz charts/
-          ./linux-amd64/helm repo index charts/
+          helm repo index charts/
+      
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add ../charts/
+          git commit -m "Updated Helm charts"
+          git push origin master
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
@@ -41,5 +47,3 @@ jobs:
           force_orphan: false
           deploy_key: ${{ secrets.DEPLOY_KEY }}
           branch: ${{ env.BRANCH }}
-
-

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -29,6 +29,10 @@ jobs:
           done
           mkdir -p charts
           mv *.tgz charts/
+          if [[ "${{ env.BRANCH }}" != "master" ]]; then
+            mkdir -p "charts/${{ env.BRANCH }}"
+            mv charts/*.tgz "charts/${{ env.BRANCH }}/"
+          fi
           helm repo index charts/
       
       - name: Commit and push changes
@@ -48,3 +52,4 @@ jobs:
           force_orphan: false
           deploy_key: ${{ secrets.DEPLOY_KEY }}
           branch: ${{ env.BRANCH }}
+          destination_dir: ${{ env.BRANCH }}

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -28,10 +28,11 @@ jobs:
             fi
           done
           mkdir -p charts
-          mv *.tgz charts/
           if [[ "${{ env.BRANCH }}" != "master" ]]; then
             mkdir -p "charts/${{ env.BRANCH }}"
-            cp charts/*.tgz "charts/${{ env.BRANCH }}/"
+            mv *.tgz "charts/${{ env.BRANCH }}/"
+          else
+           mv *.tgz charts/
           fi
           helm repo index charts/
       
@@ -52,4 +53,3 @@ jobs:
           force_orphan: false
           deploy_key: ${{ secrets.DEPLOY_KEY }}
           branch: ${{ env.BRANCH }}
-          destination_dir: ${{ env.BRANCH }}

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -28,22 +28,8 @@ jobs:
             fi
           done
           mkdir -p charts
-          if [[ "${{ env.BRANCH }}" != "master" ]]; then
-            mkdir -p "charts/${{ env.BRANCH }}"
-            mv *.tgz "charts/${{ env.BRANCH }}/"
-          else
-           mv *.tgz charts/
-          fi
+          mv *.tgz charts/
           helm repo index charts/
-      
-      - name: Commit and push changes
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add ../charts/
-          git commit -m "Updated Helm charts"
-          git push origin master
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/package-and-publish.yaml
+++ b/.github/workflows/package-and-publish.yaml
@@ -31,7 +31,7 @@ jobs:
           mv *.tgz charts/
           if [[ "${{ env.BRANCH }}" != "master" ]]; then
             mkdir -p "charts/${{ env.BRANCH }}"
-            mv charts/*.tgz "charts/${{ env.BRANCH }}/"
+            cp charts/*.tgz "charts/${{ env.BRANCH }}/"
           fi
           helm repo index charts/
       


### PR DESCRIPTION
Changed `keep_files: false` Since I'm taking previous built charts from gh-pages branch and processing previous version out of it

Now index.yaml will have all old version of charts listed - https://github.com/Facets-cloud/helm-charts/blob/gh-pages/index.yaml

[Package and Publish Helm Chart](https://github.com/Facets-cloud/helm-charts/actions/runs/12928937276)
[pages build and deployment](https://github.com/Facets-cloud/helm-charts/actions/runs/12928941390)
