### PR TITLE
publish v1.1.0 version of database operator

### DIFF
--- a/database-operator/Chart.yaml
+++ b/database-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: database-operator
 description: A Helm chart for database operator
 type: application
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.1.0
+appVersion: 1.1.0
 home: https://facets-cloud.github.io
 sources:
   - https://github.com/Facets-cloud/helm-charts/tree/master/database-operator

--- a/database-operator/crds/grant.yaml
+++ b/database-operator/crds/grant.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: grants.postgresql.facets.cloud
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+spec:
+  group: postgresql.facets.cloud
+  names:
+    kind: Grant
+    listKind: GrantList
+    plural: grants
+    singular: grant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.roleRef.name
+      name: For Role
+      type: string
+    - jsonPath: .status.conditions[-1:].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[-1:].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[-1:].message
+      name: Message
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[-1:].lastTransitionTime
+      name: Last Transition Time
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Grant is the Schema for the grants API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GrantSpec defines the desired state of Grant
+            properties:
+              database:
+                description: Defines the Database to grant permission for a role
+                type: string
+              privileges:
+                description: Defines the list of permissions to grant for a role
+                items:
+                  type: string
+                type: array
+              roleRef:
+                description: Defines the role reference to grant permissions
+                properties:
+                  name:
+                    description: Name of the resource.
+                    type: string
+                  namespace:
+                    description: Namespace of the resource.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              schema:
+                default: ""
+                description: Defines the Schema to grant permission for a role
+                type: string
+              table:
+                default: ""
+                description: Defines the Database to grant permission for a role
+                type: string
+            type: object
+          status:
+            description: GrantStatus defines the observed state of Grant
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details
+                        about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers of
+                        specific condition types may define expected values and meanings
+                        for this field, and whether the values are considered a guaranteed
+                        API. The value should be a CamelCase string. This field may
+                        not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              previousState:
+                description: Store Previous state
+                properties:
+                  database:
+                    type: string
+                  privileges:
+                    items:
+                      type: string
+                    type: array
+                  schema:
+                    type: string
+                  table:
+                    type: string
+                  type:
+                    type: string
+                type: object
+            required:
+            - conditions
+            - previousState
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/database-operator/crds/grantstatement.yaml
+++ b/database-operator/crds/grantstatement.yaml
@@ -1,33 +1,30 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: grants.postgresql.facets.cloud
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-  labels:
-  {{- include "database-operator.labels" . | nindent 4 }}
+  name: grantstatements.postgresql.facets.cloud
 spec:
   group: postgresql.facets.cloud
   names:
-    kind: Grant
-    listKind: GrantList
-    plural: grants
-    singular: grant
+    kind: GrantStatement
+    listKind: GrantStatementList
+    plural: grantstatements
+    singular: grantstatement
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.database
+      name: Database
+      type: string
     - jsonPath: .spec.roleRef.name
-      name: For Role
+      name: Role
       type: string
     - jsonPath: .status.conditions[-1:].status
       name: Status
       type: string
     - jsonPath: .status.conditions[-1:].reason
       name: Reason
-      type: string
-    - jsonPath: .status.conditions[-1:].message
-      name: Message
-      priority: 1
       type: string
     - jsonPath: .status.conditions[-1:].lastTransitionTime
       name: Last Transition Time
@@ -39,7 +36,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Grant is the Schema for the grants API
+        description: GrantStatement is the Schema for the grantstatements API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -54,18 +51,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: GrantSpec defines the desired state of Grant
+            description: GrantStatementSpec defines the desired state of GrantStatement
             properties:
               database:
-                description: Defines the Database to grant permission for a role
                 type: string
-              privileges:
-                description: Defines the list of permissions to grant for a role
-                items:
-                  type: string
-                type: array
               roleRef:
-                description: Defines the role reference to grant permissions
+                description: A ResourceReference is a reference to a resource in an
+                  arbitrary namespace.
                 properties:
                   name:
                     description: Name of the resource.
@@ -77,25 +69,26 @@ spec:
                 - name
                 - namespace
                 type: object
-              schema:
-                default: ""
-                description: Defines the Schema to grant permission for a role
-                type: string
-              table:
-                default: ""
-                description: Defines the Database to grant permission for a role
-                type: string
+              statements:
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - database
+            - roleRef
+            - statements
             type: object
           status:
-            description: GrantStatus defines the observed state of Grant
+            description: GrantStatementStatus defines the observed state of GrantStatement
             properties:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -109,8 +102,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details
-                        about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
@@ -124,11 +117,11 @@ spec:
                       type: integer
                     reason:
                       description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers of
-                        specific condition types may define expected values and meanings
-                        for this field, and whether the values are considered a guaranteed
-                        API. The value should be a CamelCase string. This field may
-                        not be empty.
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -157,34 +150,36 @@ spec:
                   - type
                   type: object
                 type: array
-              previousState:
-                description: Store Previous state
+              previousGrantStatementState:
                 properties:
                   database:
                     type: string
-                  privileges:
+                  roleRef:
+                    description: A ResourceReference is a reference to a resource
+                      in an arbitrary namespace.
+                    properties:
+                      name:
+                        description: Name of the resource.
+                        type: string
+                      namespace:
+                        description: Namespace of the resource.
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  statements:
                     items:
                       type: string
                     type: array
-                  schema:
-                    type: string
-                  table:
-                    type: string
-                  type:
-                    type: string
+                required:
+                - database
+                - roleRef
+                - statements
                 type: object
-            required:
-            - conditions
-            - previousState
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/database-operator/crds/role.yaml
+++ b/database-operator/crds/role.yaml
@@ -4,8 +4,6 @@ metadata:
   name: roles.postgresql.facets.cloud
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-  labels:
-  {{- include "database-operator.labels" . | nindent 4 }}
 spec:
   group: postgresql.facets.cloud
   names:

--- a/database-operator/examples/db-grantstatement.yaml
+++ b/database-operator/examples/db-grantstatement.yaml
@@ -1,0 +1,34 @@
+apiVersion: postgresql.facets.cloud/v1alpha1
+kind: GrantStatement
+metadata:
+  labels:
+    app.kubernetes.io/name: test-grantstatement
+    app.kubernetes.io/instance: test-grantstatement
+    app.kubernetes.io/part-of: postgresql-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: postgresql-operator
+  name: test-grantstatement
+spec:
+  roleRef:
+    name: test-role
+    namespace: default
+  database: postgres
+  statements:
+    # Query to allow connect to db
+    - 'GRANT CONNECT ON DATABASE postgres TO "test-role";'
+    # Query to grant usage on schema public to role test-role
+    - 'GRANT USAGE ON SCHEMA public TO "test-role";'
+    # Query to grant all privileges on all tables in schema public to role test-role
+    - 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "test-role";'
+    # Query to grant usage on all sequences in schema public to role test-role
+    - 'GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+    # Query to grant all on all functions in schema public to role test-role
+    - 'GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO "test-role";'
+    # Query to grant all privileges on all sequences in schema public to role test-role
+    - 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO "test-role";'
+    # Query to grant all privileges on all tables that will be created in schema public to role test-role
+    - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "test-role";'
+    # Query to grant all privileges on all sequences that will be created in schema public to role test-role
+    - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "test-role";'
+    # Query to grant all privileges on all functions that will be created in schema public to role test-role
+    - 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO "test-role";'

--- a/database-operator/templates/manager-rbac.yaml
+++ b/database-operator/templates/manager-rbac.yaml
@@ -65,6 +65,32 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - postgresql.facets.cloud
+  resources:
+  - grantstatements
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.facets.cloud
+  resources:
+  - grantstatements/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - postgresql.facets.cloud
+  resources:
+  - grantstatements/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR updates the helm chart for postgresql operator for `v1.1.0` which supports new CRD `GrantStatement` for granting permissions for role created.

Changes:
- Moved CRDs to `/crds` directory as recommended by official helm documentation.
- Added sample `GrantStatement` crd.
- Updated the manager rbac to add permissions for new crd.


Testing:
Published `v1.1.0` version of postgresql operator to docker registry, updated the helm chart version in database operated module and verified everything works fine. 
Test Cases: https://github.com/Facets-cloud/facets-modules/pull/271