### PR TITLE
[S78] Feature: Added node selector and tolerations for Image Pull Secrets Injector

### DIFF
--- a/image-pull-secret-injector/templates/deployment.yaml
+++ b/image-pull-secret-injector/templates/deployment.yaml
@@ -82,3 +82,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "chart.fullname" . }}-tls
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/image-pull-secret-injector/values.yaml
+++ b/image-pull-secret-injector/values.yaml
@@ -61,3 +61,6 @@ leaderElection:
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
+
+nodeSelector: {}
+tolerations: []


### PR DESCRIPTION
## Without Node Selector and Tolerations
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/719a2607-7704-4877-9a7b-9448b8be5346" />


## With Node Selector and Tolerations
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/168a79d4-69ce-4cca-883c-ae4bb750dfca" />
