### PR TITLE
Fix scaler

### DIFF
--- a/scheduled-deployment-scaler/Chart.yaml
+++ b/scheduled-deployment-scaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: scheduled-deployment-scaler
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0
 description: A Helm chart to schedule scaling of a deployment in a Kubernetes cluster
 home: https://facets-cloud.github.io

--- a/scheduled-deployment-scaler/README.md
+++ b/scheduled-deployment-scaler/README.md
@@ -24,7 +24,7 @@ The following table lists the values accepted by the chart
 ```bash
 helm repo add facets-cloud https://facets-cloud.github.io/helm-charts
 
-helm install helm install myrelease facets-cloud/scheduled-deployment-scaler -f my-scaling-schedules.yaml
+helm install myrelease facets-cloud/scheduled-deployment-scaler -f my-scaling-schedules.yaml
 ```
 
 ## Sample Values
@@ -32,12 +32,12 @@ helm install helm install myrelease facets-cloud/scheduled-deployment-scaler -f 
 ```yaml
 scalingSchedules:
   schedule1:
-    schedule: "0 45 22 * * *"
+    schedule: "0 4 2 * *"
     deployment: deployment1
     desiredReplicas: 4
     namespace: default
   schedule2:
-    schedule: "0 0 * * * *"
+    schedule: "0 0 * * *"
     deployment: deployment2
     desiredReplicas: 2
     namespace: test-namespace

--- a/scheduled-deployment-scaler/templates/scheduled-scaler-crons.yaml
+++ b/scheduled-deployment-scaler/templates/scheduled-scaler-crons.yaml
@@ -18,7 +18,7 @@ spec:
           containers:
             - name: scaling-job
               image: bitnami/kubectl:1.21
-              command: ["/bin/sh", "-c", "kubectl scale --replicas={{ $schedule.desiredReplicas }} deployment {{ $schedule.deployment }} -n {{ default $schedule.namespace "default" }}"]
+              command: ["/bin/sh", "-c", "kubectl scale --replicas={{ $schedule.desiredReplicas }} deployment {{ $schedule.deployment }} -n {{ $schedule.namespace | default "default" }}"]
           restartPolicy: OnFailure
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1


### PR DESCRIPTION
Fixing the default namespace issue where always default namespace is getting picked

1. before fix
- passing different namespace
<img width="728" alt="image" src="https://github.com/user-attachments/assets/19a12b69-aece-4bd9-b226-467cf39cc568" />
- always picking "default" value
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/2fd537d6-a802-433b-9146-441001f15bba" />



2. After fix
- passing diff namespace
<img width="398" alt="image" src="https://github.com/user-attachments/assets/9289e433-6315-4989-9bd8-87408eae18cf" />
- picking correct namespace
<img width="787" alt="image" src="https://github.com/user-attachments/assets/f911e886-6fd4-45bb-89be-b0235ae37b28" />

3. if no namespace is passed - "default is picked
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/7cab13eb-eaa1-45f8-8d2a-9c2b595d9493" />
