### PR TITLE
pin to shell-operator image with jq flant compatibility

### DIFF
--- a/secret-copier/Chart.yaml
+++ b/secret-copier/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: secret-copier
-version: 1.0.1
+version: 1.0.2
 description: Used to copy secrets from default namespace to all other namespaces.

--- a/secret-copier/templates/shell-operator-deployment.yaml
+++ b/secret-copier/templates/shell-operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: shell-operator
-        image: "ghcr.io/flant/shell-operator:latest"
+        image: "ghcr.io/flant/shell-operator:v1.6.1"
         imagePullPolicy: Always
         volumeMounts:
         - name: {{ .Release.Name }}


### PR DESCRIPTION
Our secret-copier script breaks with latest shell-operator base image changed

changes ref - https://github.com/flant/shell-operator/commit/7b3a6bdf0b0e1fad9d8e8c36fc08231fd8b8b227

This PR pins the secret-copier to v1.6.1 shell-operator with flant/jq compatibility.

This is tested and working with pinned version.

(error with new image)
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/37547d83-e9ef-4123-a451-6ba5f3e04049" />
