### PR TITLE
update helm chart for mongo operator

### DIFF
--- a/mongodb-auth-operator/Chart.yaml
+++ b/mongodb-auth-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mongodb-auth-operator/examples/usage.md
+++ b/mongodb-auth-operator/examples/usage.md
@@ -25,9 +25,10 @@ spec:
   dbRoles:
     - db: testdb
       role: test-role-1
+  userNameOverride: actual-user-name
 ```
 
-In this example, a new user named `test-user` is being created with the password stored in the `mongo` Kubernetes secret. The user has the `test-role-1` role in the `testdb` database.
+In this example, a new user named `actual-user-name` is being created with the password stored in the `mongo` Kubernetes secret. The user has the `test-role-1` role in the `testdb` database. If `userNameOverride` is not set the username is taken from name of the user crd created.
 
 ## Role
 

--- a/mongodb-auth-operator/examples/user.yaml
+++ b/mongodb-auth-operator/examples/user.yaml
@@ -10,9 +10,10 @@ spec:
     namespace: default
   customData:
     custom: "Example data"
-  mechanisms: ["SCRAM-SHA-1"]
+  mechanisms: [ "SCRAM-SHA-1" ]
   rolesToRole:
-    - test-role-1
+  - test-role-1
   dbRoles:
-    - db: testdb
-      role: test-role-1
+  - db: testdb
+    role: test-role-1
+  userNameOverride: actual-user-name

--- a/mongodb-auth-operator/templates/leader_election_rbac.yaml
+++ b/mongodb-auth-operator/templates/leader_election_rbac.yaml
@@ -11,6 +11,18 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/mongodb-auth-operator/templates/manager-rbac.yaml
+++ b/mongodb-auth-operator/templates/manager-rbac.yaml
@@ -68,6 +68,13 @@ rules:
     - get
     - patch
     - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/mongodb-auth-operator/templates/roles-crd.yaml
+++ b/mongodb-auth-operator/templates/roles-crd.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: roles.mongo.facets.cloud
   labels:
     {{- include "mongodb-auth-operator.labels" . | nindent 4 }}
@@ -35,14 +34,19 @@ spec:
         description: Role is the Schema for the roles API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -94,43 +98,35 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -145,10 +141,6 @@ spec:
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -207,9 +199,9 @@ spec:
               reason:
                 type: string
               status:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 type: string
             type: object
         type: object

--- a/mongodb-auth-operator/templates/users-crd.yaml
+++ b/mongodb-auth-operator/templates/users-crd.yaml
@@ -110,6 +110,7 @@ spec:
                 type: array
               userNameOverride:
                 type: string
+                description: The name to use mongo user. If not specified, the user name will default to the name of the user resource.
             type: object
           status:
             description: UserStatus defines the observed state of User
@@ -233,7 +234,6 @@ spec:
                     type: array
                   userNameOverride:
                     type: string
-                    description: The name to use mongo user. If not specified, the user name will default to the name of the user resource.
                 type: object
               message:
                 type: string

--- a/mongodb-auth-operator/templates/users-crd.yaml
+++ b/mongodb-auth-operator/templates/users-crd.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: users.mongo.facets.cloud
   labels:
   {{- include "mongodb-auth-operator.labels" . | nindent 4 }}
@@ -35,14 +34,19 @@ spec:
         description: User is the Schema for the users API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -68,7 +72,9 @@ spec:
               customData:
                 additionalProperties:
                   type: string
-                description: Any arbitrary information. This field can be used to store any data an admin wishes to associate with this particular user. For example, this could be the user's full name or employee id.
+                description: |-
+                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 type: object
               database:
                 type: string
@@ -102,50 +108,43 @@ spec:
                 items:
                   type: string
                 type: array
-                description: The roles granted to the user
+              userNameOverride:
+                type: string
             type: object
           status:
             description: UserStatus defines the observed state of User
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -179,9 +178,9 @@ spec:
                 items:
                   type: string
                 type: array
-              lastObserverdPassword:
+              lastObservedPassword:
                 type: string
-              lastObserverdSpec:
+              lastObservedSpec:
                 description: UserSpec defines the desired state of User
                 properties:
                   authenticationRestrictions:
@@ -202,9 +201,9 @@ spec:
                   customData:
                     additionalProperties:
                       type: string
-                    description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of
-                      cluster Important: Run "make" to regenerate code after modifying
-                      this file'
+                    description: |-
+                      INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                      Important: Run "make" to regenerate code after modifying this file
                     type: object
                   database:
                     type: string
@@ -232,15 +231,18 @@ spec:
                     items:
                       type: string
                     type: array
+                  userNameOverride:
+                    type: string
+                    description: The name to use mongo user. If not specified, the user name will default to the name of the user resource.
                 type: object
               message:
                 type: string
               reason:
                 type: string
               status:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 type: string
             type: object
         type: object

--- a/mongodb-auth-operator/values.yaml
+++ b/mongodb-auth-operator/values.yaml
@@ -28,7 +28,7 @@ controllerManager:
       - --leader-elect
     image:
       repository: facetscloud/mongodb-auth-operator
-      tag: 2
+      tag: 13
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
- updated the mongo user crd
- fixed the cluster role for manager container, was getting the below error
```bash
manager E0603 10:13:43.833280       1 event.go:267] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"mongo-user-mongo-user-3-1-user.18458080da8cbf6d", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"User", Namespace:"default", Name:"mongo-user-mongo-user-3-1-user", UID:"7d1ad71e-209b-4143-a828-ef6b08658503", APIVersion:"mongo.facets.cloud/v1alpha1", ResourceVersion:"32898", FieldPath:""}, Reason:"UserReconciled", Message:"Successfully reconciled the mongo-user-mongo-user-3-1-user user with username mongo-user-mongo-user-3-1", Source:v1.EventSource{Component:"mongodb-operator", Host:""}, FirstTimestamp:time.Date(2025, time.June, 3, 10, 8, 41, 214132077, time.Local), LastTimestamp:time.Date(2025, time.June, 3, 10, 13, 43, 828411035, time.Local), Count:32, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events "mongo-user-mongo-user-3-1-user.18458080da8cbf6d" is forbidden: User "system:serviceaccount:facets:mongodb-auth-operator-controller-manager" cannot patch resource "events" in API group "" in the namespace "default"' (will not retry!)

```

Testing is present here
https://github.com/Facets-cloud/facets-modules/pull/393/files
