### PR TITLE
Sync iac-operator CRD: flatten artifacts to string + expand artifactoryType enum

### DIFF
--- a/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
@@ -76,9 +76,13 @@ spec:
                         description: ArtifactoryType specifies the type
                         enum:
                           - ECR
-                          - ACR
-                          - GCR
-                          - DOCKERHUB
+                          - AZURE_CONTAINER_REGISTRY
+                          - GOOGLE_ARTIFACT_REGISTRY
+                          - GOOGLE_CONTAINER_REGISTRY
+                          - NEXUS
+                          - DOCKER_HUB
+                          - JFROG
+                          - HARBOR
                           - OTHERS
                         type: string
                       awsAccountID:
@@ -113,17 +117,7 @@ spec:
                   properties:
                     artifacts:
                       additionalProperties:
-                        description: Artifact defines a container artifact
-                        properties:
-                          buildID:
-                            description: BuildID for tracking
-                            type: string
-                          uri:
-                            description: URI of the artifact
-                            type: string
-                        required:
-                          - uri
-                        type: object
+                        type: string
                       description: Artifacts defines artifact references
                       type: object
                     secretRef:


### PR DESCRIPTION
## Summary

Syncs the iac-operator CRD template to match the CRD changes in [iac-generator#79](https://github.com/Facets-cloud/iac-generator/pull/79).

1. **`blueprintAttributes.artifacts`** — flattened from nested `{uri, buildID}` object to bare string values. `buildID` isn't consumed anywhere in the release pipeline; deployment tracking uses `release_metadata.artifact_url` (not `blueprint_self.artifacts`), and service modules read `spec.release.image` as a bare string.

2. **`artifactoryType` enum — expanded from 5 to 9 values.**
   - Old: `ECR, ACR, GCR, DOCKERHUB, OTHERS`
   - New: `ECR, AZURE_CONTAINER_REGISTRY, GOOGLE_ARTIFACT_REGISTRY, GOOGLE_CONTAINER_REGISTRY, NEXUS, DOCKER_HUB, JFROG, HARBOR, OTHERS`
   - CP emits the new values; K8s admission was rejecting against the old enum.

## Test plan
- [x] `yaml.safe_load` parses the modified CRD cleanly
- [x] `additionalProperties: { type: string }` verified under `blueprintAttributes.artifacts`
- [x] Enum list verified (9 values, matches what CP emits)
- [ ] Install the chart on a fresh cluster and verify the CRD registers
- [ ] Create a sample Release with the new `artifacts` shape and confirm no validation error

## Related
- Must land together with: [iac-generator#79](https://github.com/Facets-cloud/iac-generator/pull/79) and the pending control-plane `ReleaseCrdMapper` one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)