### PR TITLE
Bump iac-operator chart to 0.1.15 (image tag operator-v0.1.15)

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.14
-appVersion: "0.1.14"
+version: 0.1.15
+appVersion: "0.1.15"
 keywords:
   - iac
   - terraform

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: facetscloud/iac-operator
   pullPolicy: IfNotPresent
-  tag: "operator-v0.1.14"
+  tag: "operator-v0.1.15"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

Follow-up to #45, which updated the CRD template but missed the chart version + image tag bumps. Without this, the generated chart would still deploy `operator-v0.1.14`, even though the new operator binary and CRD schema are ready at `operator-v0.1.15`.

Three fields updated together:

| File | Field | Before | After |
|---|---|---|---|
| `iac-operator/values.yaml` | `image.tag` | `operator-v0.1.14` | `operator-v0.1.15` |
| `iac-operator/Chart.yaml` | `version` | `0.1.14` | `0.1.15` |
| `iac-operator/Chart.yaml` | `appVersion` | `"0.1.14"` | `"0.1.15"` |

The operator image at `facetscloud/iac-operator:operator-v0.1.15` is built from tag `operator-v0.1.15` on iac-generator's main (pushed after #80 merged).

## Related
- [iac-generator #79](https://github.com/Facets-cloud/iac-generator/pull/79) (merged) — CRD schema flatten + artifactoryType enum
- [iac-generator #80](https://github.com/Facets-cloud/iac-generator/pull/80) (merged) — remove app legacy-compat branch
- #45 (merged) — updated the CRD template (this PR completes the chart bump)

## Test plan
- [x] `values.yaml` image tag matches the operator git tag `operator-v0.1.15`
- [x] `Chart.yaml` `version` + `appVersion` bumped in lockstep
- [ ] Install the chart on a fresh cluster and verify operator pod pulls the new image
- [ ] Verify the Release CRD registers with the updated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)