### PR TITLE
Sync iac-operator CRD: opaque advanced map to preserve user overrides

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.15
-appVersion: "0.1.15"
+version: 0.1.16
+appVersion: "0.1.16"
 keywords:
   - iac
   - terraform

--- a/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
@@ -390,13 +390,16 @@ spec:
                               description: ResourceYaml contains the resource definition
                               properties:
                                 advanced:
-                                  description: Advanced contains advanced metadata
-                                  properties:
-                                    inheritFromBase:
-                                      description:
-                                        InheritFromBase indicates whether
-                                        to inherit configuration from the base environment
-                                      type: boolean
+                                  additionalProperties:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    "Advanced contains advanced metadata —
+                                    opaque map preserved through the CRD.
+                                    Serves as an escape hatch for per-resource
+                                    overrides (e.g. common app-chart values,
+                                    node selectors, helm hints) that aren't
+                                    otherwise modeled in the schema. Any JSON
+                                    shape is accepted."
                                   type: object
                                 disabled:
                                   description: Disabled flag

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: facetscloud/iac-operator
   pullPolicy: IfNotPresent
-  tag: "operator-v0.1.15"
+  tag: "operator-v0.1.16"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

Mirrors the CRD schema change in [iac-generator#81](https://github.com/Facets-cloud/iac-generator/pull/81).

`resourceYaml.advanced` was a strict object with only `{inheritFromBase bool}` and no `preserveUnknownFields` marker. K8s API admission was pruning any additional nested content on write — so user blueprint overrides like `advanced.common.app_chart.values.node_selector.nodepool` got silently dropped before reaching the operator / generator.

New schema:

```yaml
advanced:
  additionalProperties:
    x-kubernetes-preserve-unknown-fields: true
  type: object
```

Any JSON shape under `advanced` is now preserved verbatim through the CRD.

## Test plan
- [x] YAML parses cleanly (validated with `yaml.safe_load`)
- [x] `additionalProperties: { x-kubernetes-preserve-unknown-fields: true }` verified under `resourceYaml.advanced`
- [ ] Install chart + deploy a release with a real `advanced.*` override; verify it survives the pipeline end-to-end

## Related
- iac-generator [#81](https://github.com/Facets-cloud/iac-generator/pull/81) — Go type + deepcopy + kubebuilder regen for the operator side
- Fixes the `nodepool: default-pool` disappearance on standalone-agent/dev's service resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)