### PR TITLE
Sync iac-operator chart for artifacts schema split (chart 0.1.17, operator-v0.1.17)

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.16
-appVersion: "0.1.16"
+version: 0.1.17
+appVersion: "0.1.17"
 keywords:
   - iac
   - terraform

--- a/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
@@ -117,7 +117,23 @@ spec:
                   properties:
                     artifacts:
                       additionalProperties:
-                        type: string
+                        description:
+                          Artifact represents a resolved CI artifact with
+                          URI and build identifier.
+                        properties:
+                          artifactUri:
+                            description:
+                              ArtifactURI is the resolved container image
+                              URI or artifact URI.
+                            type: string
+                          buildID:
+                            description: |-
+                              BuildID identifies the specific build that produced this artifact.
+                              Used by modules to trigger pod restarts on rebuild even when the image tag is unchanged.
+                            type: string
+                        required:
+                          - artifactUri
+                        type: object
                       description: Artifacts defines artifact references
                       type: object
                     secretRef:
@@ -368,6 +384,15 @@ spec:
                                 ResourceReleaseMetadata contains release
                                 metadata for this resource
                               properties:
+                                artifactUrl:
+                                  description: |-
+                                    ArtifactURL is the resolved container image URI / artifact URL for this resource.
+                                    Backend-resolved per-resource (mirrors deploymentcontext.json.resourceMetadata[*].artifactUrl
+                                    in the legacy Python framework). Surfaces in TF state as release_metadata.metadata.artifact_url.
+                                    Required to be present in the payload, but nullable — backend sends null for resources
+                                    without an artifact (non-service kinds, literal images, no Mongo match).
+                                  nullable: true
+                                  type: string
                                 commitID:
                                   description:
                                     CommitID references the commit that created/updated
@@ -384,6 +409,7 @@ spec:
                                     for this override version
                                   type: string
                               required:
+                                - artifactUrl
                                 - commitID
                               type: object
                             resourceYaml:
@@ -392,14 +418,11 @@ spec:
                                 advanced:
                                   additionalProperties:
                                     x-kubernetes-preserve-unknown-fields: true
-                                  description:
-                                    "Advanced contains advanced metadata —
-                                    opaque map preserved through the CRD.
-                                    Serves as an escape hatch for per-resource
-                                    overrides (e.g. common app-chart values,
-                                    node selectors, helm hints) that aren't
-                                    otherwise modeled in the schema. Any JSON
-                                    shape is accepted."
+                                  description: |-
+                                    Advanced contains advanced metadata — opaque map preserved through the
+                                    CRD. Serves as an escape hatch for per-resource overrides (e.g. common
+                                    app-chart values, node selectors, helm hints) that aren't otherwise
+                                    modeled in the schema. Any JSON shape is accepted.
                                   type: object
                                 disabled:
                                   description: Disabled flag

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: facetscloud/iac-operator
   pullPolicy: IfNotPresent
-  tag: "operator-v0.1.16"
+  tag: "operator-v0.1.17"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

Mirrors the artifact-schema change merged in [iac-generator #84](https://github.com/Facets-cloud/iac-generator/pull/84).

- **CRD sync** (`iac.facets.cloud_releases.yaml`): `BlueprintAttributes.artifacts` is now `map<ci_name, Artifact>` where `Artifact = {artifactUri (required), buildId (optional)}` — matches what existing modules already read off the matrix. `ResourceReleaseMetadata` gains `artifactUrl` (string, required + nullable). The bulk of the diff is controller-gen-driven indentation normalization that landed alongside the schema additions.
- **Chart bump** `0.1.16` → `0.1.17`, image tag `operator-v0.1.16` → `operator-v0.1.17`. Without the version bump, `helm upgrade` wouldn't pick up the regenerated CRD schema or the new operator image carrying the matching Go types.

## Test plan

- [ ] `helm template ./iac-operator` renders without errors.
- [ ] `helm lint ./iac-operator` passes.
- [ ] `helm upgrade --install iac-operator ./iac-operator -n facets` against a dev cluster picks up the new CRD schema.
- [ ] `kubectl explain release.spec.blueprintAttributes.artifacts` shows the object shape.
- [ ] `kubectl explain release.spec.modules.resources.resourceReleaseMetadata.artifactUrl` shows nullable: true.
- [ ] `kubectl get releases` reconcile loop runs without informer-sync errors against existing CRDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)