### PR TITLE
Sync iac-operator chart for phase-scoped env lock (chart 0.1.18, operator-v0.1.18)

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.17
-appVersion: "0.1.17"
+version: 0.1.18
+appVersion: "0.1.18"
 keywords:
   - iac
   - terraform

--- a/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
@@ -14,814 +14,768 @@ spec:
     singular: release
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-        - jsonPath: .spec.environment.id
-          name: Environment
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Current-Phase
-          type: string
-        - jsonPath: .status.approvalPhase
-          name: Approval-Phase
-          type: string
-        - jsonPath: .status.queuePosition
-          name: Queue-Pos
-          type: integer
-        - jsonPath: .status.environmentLocked
-          name: Locked
-          type: boolean
-        - jsonPath: .status.approvalRequired
-          name: Approval-Req
-          type: boolean
-        - jsonPath: .status.duration
-          name: Duration
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: Release is the Schema for the releases API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ReleaseSpec defines the desired state of Release.
-              properties:
-                artifactories:
-                  description: Artifactories defines container registry configurations
-                  items:
-                    description: Artifactory defines a container registry
-                    properties:
-                      artifactoryType:
-                        description: ArtifactoryType specifies the type
-                        enum:
-                          - ECR
-                          - AZURE_CONTAINER_REGISTRY
-                          - GOOGLE_ARTIFACT_REGISTRY
-                          - GOOGLE_CONTAINER_REGISTRY
-                          - NEXUS
-                          - DOCKER_HUB
-                          - JFROG
-                          - HARBOR
-                          - OTHERS
-                        type: string
-                      awsAccountID:
-                        type: string
-                      awsKey:
-                        description: AWS specific fields
-                        type: string
-                      awsRegion:
-                        type: string
-                      awsSecret:
-                        type: string
-                      name:
-                        description: Name of the artifactory
-                        type: string
-                      password:
-                        description: Password for authentication
-                        type: string
-                      uri:
-                        description: URI of the artifactory
-                        type: string
-                      username:
-                        description: Username for authentication
-                        type: string
-                    required:
-                      - artifactoryType
-                      - name
-                      - uri
-                    type: object
-                  type: array
-                blueprintAttributes:
-                  description: BlueprintAttributes contains blueprint-specific configuration
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.environment.id
+      name: Environment
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Current-Phase
+      type: string
+    - jsonPath: .status.approvalPhase
+      name: Approval-Phase
+      type: string
+    - jsonPath: .status.queuePosition
+      name: Queue-Pos
+      type: integer
+    - jsonPath: .status.environmentLocked
+      name: Locked
+      type: boolean
+    - jsonPath: .status.approvalRequired
+      name: Approval-Req
+      type: boolean
+    - jsonPath: .status.duration
+      name: Duration
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Release is the Schema for the releases API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReleaseSpec defines the desired state of Release.
+            properties:
+              artifactories:
+                description: Artifactories defines container registry configurations
+                items:
+                  description: Artifactory defines a container registry
                   properties:
-                    artifacts:
-                      additionalProperties:
-                        description:
-                          Artifact represents a resolved CI artifact with
-                          URI and build identifier.
-                        properties:
-                          artifactUri:
-                            description:
-                              ArtifactURI is the resolved container image
-                              URI or artifact URI.
-                            type: string
-                          buildID:
-                            description: |-
-                              BuildID identifies the specific build that produced this artifact.
-                              Used by modules to trigger pod restarts on rebuild even when the image tag is unchanged.
-                            type: string
-                        required:
-                          - artifactUri
-                        type: object
-                      description: Artifacts defines artifact references
-                      type: object
-                    secretRef:
-                      description:
-                        SecretRef references a secret containing sensitive
-                        data
-                      properties:
-                        cloud:
-                          description: Cloud provider
-                          enum:
-                            - aws
-                            - azure
-                            - gcp
-                          type: string
-                        key:
-                          description: Key or ARN of the secret
-                          type: string
-                        region:
-                          description: Region specifies the cloud region for the secret
-                          type: string
-                      required:
-                        - cloud
-                        - key
-                        - region
-                      type: object
-                    variables:
-                      additionalProperties:
-                        type: string
-                      description: Variables defines blueprint variables
-                      type: object
-                  required:
-                    - artifacts
-                    - secretRef
-                    - variables
-                  type: object
-                environment:
-                  description: Environment identifies the target environment
-                  properties:
+                    artifactoryType:
+                      description: ArtifactoryType specifies the type
+                      enum:
+                      - ECR
+                      - AZURE_CONTAINER_REGISTRY
+                      - GOOGLE_ARTIFACT_REGISTRY
+                      - GOOGLE_CONTAINER_REGISTRY
+                      - NEXUS
+                      - DOCKER_HUB
+                      - JFROG
+                      - HARBOR
+                      - OTHERS
+                      type: string
+                    awsAccountID:
+                      type: string
+                    awsKey:
+                      description: AWS specific fields
+                      type: string
                     awsRegion:
-                      description: AWSRegion specifies the AWS region
                       type: string
-                    cloud:
-                      description: Cloud specifies the cloud provider
-                      type: string
-                    cloudTags:
-                      additionalProperties:
-                        type: string
-                      description: CloudTags contains cloud resource tags
-                      type: object
-                    commonEnvironmentVariables:
-                      additionalProperties:
-                        type: string
-                      description:
-                        CommonEnvironmentVariables contains common environment
-                        variables
-                      type: object
-                    extra:
-                      additionalProperties:
-                        type: string
-                      description:
-                        Extra contains additional environment fields that
-                        flow through to terraform var.cluster
-                      type: object
-                    globalVariables:
-                      additionalProperties:
-                        type: string
-                      description:
-                        GlobalVariables contains global variables that flow
-                        through to terraform var.cluster
-                      type: object
-                    id:
-                      description: ID is the unique identifier for the environment
+                    awsSecret:
                       type: string
                     name:
-                      description: Name of the environment
+                      description: Name of the artifactory
                       type: string
-                    parentEnvironmentID:
-                      description:
-                        ParentEnvironmentID references a parent environment
-                        for state inheritance
+                    password:
+                      description: Password for authentication
                       type: string
-                    stackName:
-                      description: StackName is the stack name for the environment
+                    uri:
+                      description: URI of the artifactory
+                      type: string
+                    username:
+                      description: Username for authentication
                       type: string
                   required:
-                    - id
-                    - name
+                  - artifactoryType
+                  - name
+                  - uri
                   type: object
-                logLevelOverride:
-                  description: LogLevelOverride overrides the default log level
-                  enum:
-                    - debug
-                    - info
-                    - warn
-                    - error
-                  type: string
-                modules:
-                  description: Modules defines the terraform modules to apply
-                  items:
-                    description: Module defines a terraform module
+                type: array
+              blueprintAttributes:
+                description: BlueprintAttributes contains blueprint-specific configuration
+                properties:
+                  artifacts:
+                    additionalProperties:
+                      description: Artifact represents a resolved CI artifact with
+                        URI and build identifier.
+                      properties:
+                        artifactUri:
+                          description: ArtifactURI is the resolved container image
+                            URI or artifact URI.
+                          type: string
+                        buildID:
+                          description: |-
+                            BuildID identifies the specific build that produced this artifact.
+                            Used by modules to trigger pod restarts on rebuild even when the image tag is unchanged.
+                          type: string
+                      required:
+                      - artifactUri
+                      type: object
+                    description: Artifacts defines artifact references
+                    type: object
+                  secretRef:
+                    description: SecretRef references a secret containing sensitive
+                      data
                     properties:
-                      moduleMetadata:
-                        description: ModuleMetadata contains module metadata
-                        properties:
-                          allowSkippingModuleOnSelectiveRelease:
-                            description:
-                              AllowSkippingModuleOnSelectiveRelease allows
-                              this module to be skipped during selective releases
-                            type: boolean
-                          alwaysUseStateReference:
-                            description:
-                              AlwaysUseStateReference forces the use of state
-                              references
-                            type: boolean
-                          clouds:
-                            description: Clouds supported by this module
-                            items:
-                              type: string
-                            type: array
-                          description:
-                            description: Description of the module
+                      cloud:
+                        description: Cloud provider
+                        enum:
+                        - aws
+                        - azure
+                        - gcp
+                        type: string
+                      key:
+                        description: Key or ARN of the secret
+                        type: string
+                      region:
+                        description: Region specifies the cloud region for the secret
+                        type: string
+                    required:
+                    - cloud
+                    - key
+                    - region
+                    type: object
+                  variables:
+                    additionalProperties:
+                      type: string
+                    description: Variables defines blueprint variables
+                    type: object
+                required:
+                - artifacts
+                - secretRef
+                - variables
+                type: object
+              environment:
+                description: Environment identifies the target environment
+                properties:
+                  awsRegion:
+                    description: AWSRegion specifies the AWS region
+                    type: string
+                  cloud:
+                    description: Cloud specifies the cloud provider
+                    type: string
+                  cloudTags:
+                    additionalProperties:
+                      type: string
+                    description: CloudTags contains cloud resource tags
+                    type: object
+                  commonEnvironmentVariables:
+                    additionalProperties:
+                      type: string
+                    description: CommonEnvironmentVariables contains common environment
+                      variables
+                    type: object
+                  extra:
+                    additionalProperties:
+                      type: string
+                    description: Extra contains additional environment fields that
+                      flow through to terraform var.cluster
+                    type: object
+                  globalVariables:
+                    additionalProperties:
+                      type: string
+                    description: GlobalVariables contains global variables that flow
+                      through to terraform var.cluster
+                    type: object
+                  id:
+                    description: ID is the unique identifier for the environment
+                    type: string
+                  name:
+                    description: Name of the environment
+                    type: string
+                  parentEnvironmentID:
+                    description: ParentEnvironmentID references a parent environment
+                      for state inheritance
+                    type: string
+                  stackName:
+                    description: StackName is the stack name for the environment
+                    type: string
+                required:
+                - id
+                - name
+                type: object
+              logLevelOverride:
+                description: LogLevelOverride overrides the default log level
+                enum:
+                - debug
+                - info
+                - warn
+                - error
+                type: string
+              modules:
+                description: Modules defines the terraform modules to apply
+                items:
+                  description: Module defines a terraform module
+                  properties:
+                    moduleMetadata:
+                      description: ModuleMetadata contains module metadata
+                      properties:
+                        allowSkippingModuleOnSelectiveRelease:
+                          description: AllowSkippingModuleOnSelectiveRelease allows
+                            this module to be skipped during selective releases
+                          type: boolean
+                        alwaysUseStateReference:
+                          description: AlwaysUseStateReference forces the use of state
+                            references
+                          type: boolean
+                        clouds:
+                          description: Clouds supported by this module
+                          items:
                             type: string
-                          disableStateReferenceOnSelectiveRelease:
-                            description:
-                              DisableStateReferenceOnSelectiveRelease disables
-                              state references for this module during selective releases
-                            type: boolean
-                          flavor:
-                            description: Flavor of the module
-                            type: string
-                          inputs:
-                            additionalProperties:
+                          type: array
+                        description:
+                          description: Description of the module
+                          type: string
+                        disableStateReferenceOnSelectiveRelease:
+                          description: DisableStateReferenceOnSelectiveRelease disables
+                            state references for this module during selective releases
+                          type: boolean
+                        flavor:
+                          description: Flavor of the module
+                          type: string
+                        inputs:
+                          additionalProperties:
+                            description: ModuleInput represents an input configuration
+                              in module metadata
+                            properties:
+                              default:
+                                description: Default provides a default input value
+                                properties:
+                                  outputName:
+                                    description: OutputName is the specific output
+                                      to reference
+                                    type: string
+                                  resourceName:
+                                    description: ResourceName is the name of the resource
+                                      to reference
+                                    type: string
+                                  resourceType:
+                                    description: ResourceType is the type of the resource
+                                      to reference
+                                    type: string
+                                required:
+                                - resourceName
+                                - resourceType
+                                type: object
                               description:
-                                ModuleInput represents an input configuration
-                                in module metadata
-                              properties:
-                                default:
-                                  description: Default provides a default input value
+                                description: Description of the input
+                                type: string
+                              providers:
+                                description: Providers lists provider names that this
+                                  input requires from the referenced resource
+                                items:
+                                  type: string
+                                type: array
+                              required:
+                                description: Required indicates if this input is mandatory
+                                type: boolean
+                              type:
+                                description: Type of the input
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          description: Inputs defines input parameter definitions
+                            for the module
+                          type: object
+                        intent:
+                          description: Intent of the module
+                          type: string
+                        outputs:
+                          additionalProperties:
+                            description: ModuleOutput represents an output configuration
+                              in module metadata
+                            properties:
+                              providers:
+                                additionalProperties:
+                                  description: Provider represents a Terraform provider
+                                    configuration
+                                  properties:
+                                    attributes:
+                                      description: Attributes contains provider-specific
+                                        attributes
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    source:
+                                      description: Source of the provider
+                                      type: string
+                                    version:
+                                      description: Version constraint for the provider
+                                      type: string
+                                  required:
+                                  - source
+                                  - version
+                                  type: object
+                                description: Providers defines provider configurations
+                                  for this output
+                                type: object
+                              type:
+                                description: Type of the output
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          description: Outputs defines output value definitions from
+                            the module
+                          type: object
+                        version:
+                          description: Version of the module
+                          type: string
+                      required:
+                      - clouds
+                      - flavor
+                      - intent
+                      - version
+                      type: object
+                    name:
+                      description: Name of the module
+                      type: string
+                    resources:
+                      description: Resources to create with this module
+                      items:
+                        description: Resource defines a resource to be created
+                        properties:
+                          name:
+                            description: Name of the resource
+                            type: string
+                          resourceReleaseMetadata:
+                            description: ResourceReleaseMetadata contains release
+                              metadata for this resource
+                            properties:
+                              artifactUrl:
+                                description: |-
+                                  ArtifactURL is the resolved container image URI / artifact URL for this resource.
+                                  Backend-resolved per-resource (mirrors deploymentcontext.json.resourceMetadata[*].artifactUrl
+                                  in the legacy Python framework). Surfaces in TF state as release_metadata.metadata.artifact_url.
+                                  Required to be present in the payload, but nullable — backend sends null for resources
+                                  without an artifact (non-service kinds, literal images, no Mongo match).
+                                nullable: true
+                                type: string
+                              commitID:
+                                description: CommitID references the commit that created/updated
+                                  this resource
+                                type: string
+                              overrideVersion:
+                                description: OverrideVersion is the override version
+                                  number
+                                type: integer
+                              overrideVersionID:
+                                description: OverrideVersionID is the unique identifier
+                                  for this override version
+                                type: string
+                            required:
+                            - artifactUrl
+                            - commitID
+                            type: object
+                          resourceYaml:
+                            description: ResourceYaml contains the resource definition
+                            properties:
+                              advanced:
+                                additionalProperties:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                description: |-
+                                  Advanced contains advanced metadata — opaque map preserved through the
+                                  CRD. Serves as an escape hatch for per-resource overrides (e.g. common
+                                  app-chart values, node selectors, helm hints) that aren't otherwise
+                                  modeled in the schema. Any JSON shape is accepted.
+                                type: object
+                              disabled:
+                                description: Disabled flag
+                                type: boolean
+                              flavor:
+                                description: Flavor of the resource
+                                type: string
+                              inputs:
+                                additionalProperties:
+                                  description: Input represents an input reference
+                                    in a resource
                                   properties:
                                     outputName:
-                                      description:
-                                        OutputName is the specific output
+                                      description: OutputName is the specific output
                                         to reference
                                       type: string
                                     resourceName:
-                                      description:
-                                        ResourceName is the name of the resource
-                                        to reference
+                                      description: ResourceName is the name of the
+                                        resource to reference
                                       type: string
                                     resourceType:
-                                      description:
-                                        ResourceType is the type of the resource
-                                        to reference
+                                      description: ResourceType is the type of the
+                                        resource to reference
                                       type: string
                                   required:
-                                    - resourceName
-                                    - resourceType
+                                  - resourceName
+                                  - resourceType
                                   type: object
-                                description:
-                                  description: Description of the input
-                                  type: string
-                                providers:
-                                  description:
-                                    Providers lists provider names that this
-                                    input requires from the referenced resource
-                                  items:
-                                    type: string
-                                  type: array
-                                required:
-                                  description: Required indicates if this input is mandatory
-                                  type: boolean
-                                type:
-                                  description: Type of the input
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            description:
-                              Inputs defines input parameter definitions
-                              for the module
-                            type: object
-                          intent:
-                            description: Intent of the module
-                            type: string
-                          outputs:
-                            additionalProperties:
-                              description:
-                                ModuleOutput represents an output configuration
-                                in module metadata
-                              properties:
-                                providers:
-                                  additionalProperties:
-                                    description:
-                                      Provider represents a Terraform provider
-                                      configuration
-                                    properties:
-                                      attributes:
-                                        description:
-                                          Attributes contains provider-specific
-                                          attributes
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      source:
-                                        description: Source of the provider
-                                        type: string
-                                      version:
-                                        description: Version constraint for the provider
-                                        type: string
-                                    required:
-                                      - source
-                                      - version
-                                    type: object
-                                  description:
-                                    Providers defines provider configurations
-                                    for this output
-                                  type: object
-                                type:
-                                  description: Type of the output
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            description:
-                              Outputs defines output value definitions from
-                              the module
-                            type: object
-                          version:
-                            description: Version of the module
-                            type: string
-                        required:
-                          - clouds
-                          - flavor
-                          - intent
-                          - version
-                        type: object
-                      name:
-                        description: Name of the module
-                        type: string
-                      resources:
-                        description: Resources to create with this module
-                        items:
-                          description: Resource defines a resource to be created
-                          properties:
-                            name:
-                              description: Name of the resource
-                              type: string
-                            resourceReleaseMetadata:
-                              description:
-                                ResourceReleaseMetadata contains release
-                                metadata for this resource
-                              properties:
-                                artifactUrl:
-                                  description: |-
-                                    ArtifactURL is the resolved container image URI / artifact URL for this resource.
-                                    Backend-resolved per-resource (mirrors deploymentcontext.json.resourceMetadata[*].artifactUrl
-                                    in the legacy Python framework). Surfaces in TF state as release_metadata.metadata.artifact_url.
-                                    Required to be present in the payload, but nullable — backend sends null for resources
-                                    without an artifact (non-service kinds, literal images, no Mongo match).
-                                  nullable: true
-                                  type: string
-                                commitID:
-                                  description:
-                                    CommitID references the commit that created/updated
-                                    this resource
-                                  type: string
-                                overrideVersion:
-                                  description:
-                                    OverrideVersion is the override version
-                                    number
-                                  type: integer
-                                overrideVersionID:
-                                  description:
-                                    OverrideVersionID is the unique identifier
-                                    for this override version
-                                  type: string
-                              required:
-                                - artifactUrl
-                                - commitID
-                              type: object
-                            resourceYaml:
-                              description: ResourceYaml contains the resource definition
-                              properties:
-                                advanced:
-                                  additionalProperties:
+                                description: Inputs defines input references for the
+                                  resource
+                                type: object
+                              kind:
+                                description: Kind of the resource
+                                type: string
+                              metadata:
+                                description: Metadata for the resource
+                                x-kubernetes-preserve-unknown-fields: true
+                              out:
+                                description: Out contains output references inherited
+                                  from parent
+                                properties:
+                                  attributes:
+                                    description: Attributes contains output attributes
                                     x-kubernetes-preserve-unknown-fields: true
-                                  description: |-
-                                    Advanced contains advanced metadata — opaque map preserved through the
-                                    CRD. Serves as an escape hatch for per-resource overrides (e.g. common
-                                    app-chart values, node selectors, helm hints) that aren't otherwise
-                                    modeled in the schema. Any JSON shape is accepted.
-                                  type: object
-                                disabled:
-                                  description: Disabled flag
-                                  type: boolean
-                                flavor:
-                                  description: Flavor of the resource
-                                  type: string
-                                inputs:
-                                  additionalProperties:
-                                    description:
-                                      Input represents an input reference
-                                      in a resource
-                                    properties:
-                                      outputName:
-                                        description:
-                                          OutputName is the specific output
-                                          to reference
-                                        type: string
-                                      resourceName:
-                                        description:
-                                          ResourceName is the name of the
-                                          resource to reference
-                                        type: string
-                                      resourceType:
-                                        description:
-                                          ResourceType is the type of the
-                                          resource to reference
-                                        type: string
-                                    required:
-                                      - resourceName
-                                      - resourceType
-                                    type: object
-                                  description:
-                                    Inputs defines input references for the
-                                    resource
-                                  type: object
-                                kind:
-                                  description: Kind of the resource
-                                  type: string
-                                metadata:
-                                  description: Metadata for the resource
-                                  x-kubernetes-preserve-unknown-fields: true
-                                out:
-                                  description:
-                                    Out contains output references inherited
-                                    from parent
-                                  properties:
-                                    attributes:
-                                      description: Attributes contains output attributes
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    interfaces:
-                                      description: Interfaces contains output interfaces
-                                      x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                spec:
-                                  description: Spec contains resource-specific configuration
-                                  x-kubernetes-preserve-unknown-fields: true
-                                version:
-                                  description: Version of the resource
-                                  type: string
-                              required:
-                                - disabled
-                                - flavor
-                                - kind
-                                - spec
-                                - version
-                              type: object
-                          required:
-                            - name
-                            - resourceYaml
-                          type: object
-                        type: array
-                      source:
-                        description: Source URL of the module
-                        type: string
-                    required:
-                      - name
-                      - source
-                    type: object
-                  minItems: 1
-                  type: array
-                overrideCommands:
-                  description: |-
-                    OverrideCommands contains custom shell commands to execute in release phases.
-                    These commands are accessible via /config/release.yaml in phase pods and can be
-                    extracted using yq in ReleaseTemplate phase commands.
-
-                    Example usage in ReleaseTemplate:
-                      yq eval '.spec.overrideCommands[]' /config/release.yaml | while read cmd; do eval "$cmd"; done
-
-                    Commands are stored in the CRD for type safety and validation, but execution
-                    logic is defined in the ReleaseTemplate phases (not handled by the operator).
-                  items:
-                    type: string
-                  maxItems: 50
-                  type: array
-                project:
-                  description: Project identifies the project name
-                  type: string
-                releaseTemplateRef:
-                  description: ReleaseTemplateRef references a ReleaseTemplate resource
-                  properties:
-                    name:
-                      description: Name of the ReleaseTemplate
-                      type: string
-                    namespace:
-                      description: Namespace of the ReleaseTemplate
+                                  interfaces:
+                                    description: Interfaces contains output interfaces
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              spec:
+                                description: Spec contains resource-specific configuration
+                                x-kubernetes-preserve-unknown-fields: true
+                              version:
+                                description: Version of the resource
+                                type: string
+                            required:
+                            - disabled
+                            - flavor
+                            - kind
+                            - spec
+                            - version
+                            type: object
+                        required:
+                        - name
+                        - resourceYaml
+                        type: object
+                      type: array
+                    source:
+                      description: Source URL of the module
                       type: string
                   required:
-                    - name
-                    - namespace
+                  - name
+                  - source
                   type: object
-                targetedResources:
-                  description: TargetedResources specifies resources to target
-                  items:
-                    description:
-                      TargetResource defines a resource to target during
-                      terraform operations
-                    properties:
-                      name:
-                        description: Name of the resource
-                        type: string
-                      type:
-                        description: Type of the resource
-                        type: string
-                    required:
-                      - name
-                      - type
-                    type: object
-                  type: array
-                terraformOptions:
-                  description: |-
-                    TerraformOptions allows override of terraform options from the template
-                    These options apply to all phases in the release
+                minItems: 1
+                type: array
+              overrideCommands:
+                description: |-
+                  OverrideCommands contains custom shell commands to execute in release phases.
+                  These commands are accessible via /config/release.yaml in phase pods and can be
+                  extracted using yq in ReleaseTemplate phase commands.
+
+                  Example usage in ReleaseTemplate:
+                    yq eval '.spec.overrideCommands[]' /config/release.yaml | while read cmd; do eval "$cmd"; done
+
+                  Commands are stored in the CRD for type safety and validation, but execution
+                  logic is defined in the ReleaseTemplate phases (not handled by the operator).
+                items:
+                  type: string
+                maxItems: 50
+                type: array
+              project:
+                description: Project identifies the project name
+                type: string
+              releaseTemplateRef:
+                description: ReleaseTemplateRef references a ReleaseTemplate resource
+                properties:
+                  name:
+                    description: Name of the ReleaseTemplate
+                    type: string
+                  namespace:
+                    description: Namespace of the ReleaseTemplate
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              targetedResources:
+                description: TargetedResources specifies resources to target
+                items:
+                  description: TargetResource defines a resource to target during
+                    terraform operations
                   properties:
-                    allowDestroy:
-                      description: |-
-                        AllowDestroy enables replacing prevent_destroy=true with prevent_destroy=false
-                        This flag is passed to iac-generator when set to true
-                      type: boolean
-                    lockTimeout:
-                      description:
-                        LockTimeout override for the template's lock timeout
-                        setting
+                    name:
+                      description: Name of the resource
                       type: string
-                    parallelism:
-                      description:
-                        Parallelism override for the template's parallelism
-                        setting
-                      type: integer
-                    refresh:
-                      description: Refresh override for the template's refresh setting
-                      type: boolean
+                    type:
+                      description: Type of the resource
+                      type: string
+                  required:
+                  - name
+                  - type
                   type: object
-              required:
-                - artifactories
-                - blueprintAttributes
-                - environment
-                - logLevelOverride
-                - modules
-                - project
-                - releaseTemplateRef
-              type: object
-            status:
-              description: ReleaseStatus defines the observed state of Release.
-              properties:
-                approvalPhase:
-                  description: ApprovalPhase indicates which phase needs approval
-                  type: string
-                approvalRequired:
-                  description: ApprovalRequired indicates if approval is currently needed
-                  type: boolean
-                completionTime:
-                  description: CompletionTime is when the release completed
-                  format: date-time
-                  type: string
-                conditions:
-                  description: Conditions represent the latest available observations
-                  items:
-                    description:
-                      Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                conflictingReleases:
-                  description:
-                    ConflictingReleases lists releases blocking this release
-                    due to resource conflicts
-                  items:
+                type: array
+              terraformOptions:
+                description: |-
+                  TerraformOptions allows override of terraform options from the template
+                  These options apply to all phases in the release
+                properties:
+                  allowDestroy:
+                    description: |-
+                      AllowDestroy enables replacing prevent_destroy=true with prevent_destroy=false
+                      This flag is passed to iac-generator when set to true
+                    type: boolean
+                  lockTimeout:
+                    description: LockTimeout override for the template's lock timeout
+                      setting
                     type: string
-                  type: array
-                currentPhase:
-                  description: CurrentPhase indicates which phase is currently executing
+                  parallelism:
+                    description: Parallelism override for the template's parallelism
+                      setting
+                    type: integer
+                  refresh:
+                    description: Refresh override for the template's refresh setting
+                    type: boolean
+                type: object
+            required:
+            - artifactories
+            - blueprintAttributes
+            - environment
+            - logLevelOverride
+            - modules
+            - project
+            - releaseTemplateRef
+            type: object
+          status:
+            description: ReleaseStatus defines the observed state of Release.
+            properties:
+              approvalPhase:
+                description: ApprovalPhase indicates which phase needs approval
+                type: string
+              approvalRequired:
+                description: ApprovalRequired indicates if approval is currently needed
+                type: boolean
+              completionTime:
+                description: CompletionTime is when the release completed
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              conflictingReleases:
+                description: ConflictingReleases lists releases blocking this release
+                  due to resource conflicts
+                items:
                   type: string
-                duration:
-                  description:
-                    Duration shows the total execution time for completed
-                    releases
+                type: array
+              currentPhase:
+                description: CurrentPhase indicates which phase is currently executing
+                type: string
+              duration:
+                description: Duration shows the total execution time for completed
+                  releases
+                type: string
+              environmentLocked:
+                description: EnvironmentLocked indicates if this release currently
+                  holds an environment lock
+                type: boolean
+              environmentLockedBy:
+                description: EnvironmentLockedBy indicates which release currently
+                  holds the environment lock
+                type: string
+              executionID:
+                description: |-
+                  ExecutionID is a unique identifier for this release execution lifecycle
+                  Used for correlating all traces/events for a single release deployment from start to finish
+                  The trace ID is deterministically derived from this execution ID
+                type: string
+              executionStartTime:
+                description: ExecutionStartTime is when the release actually started
+                  executing (transitioned to Running)
+                format: date-time
+                type: string
+              isFullRelease:
+                description: IsFullRelease indicates whether this is a full release
+                  (no targeted resources)
+                type: boolean
+              lockedResources:
+                description: LockedResources lists resources currently locked by this
+                  release
+                items:
+                  description: TargetResource defines a resource to target during
+                    terraform operations
+                  properties:
+                    name:
+                      description: Name of the resource
+                      type: string
+                    type:
+                      description: Type of the resource
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              message:
+                description: Message provides additional information about the current
+                  status
+                type: string
+              parallelReleases:
+                description: ParallelReleases lists other releases running in parallel
+                  in same environment
+                items:
                   type: string
-                environmentLocked:
-                  description:
-                    EnvironmentLocked indicates if this release currently
-                    holds an environment lock
-                  type: boolean
-                environmentLockedBy:
-                  description:
-                    EnvironmentLockedBy indicates which release currently
-                    holds the environment lock
-                  type: string
-                executionID:
-                  description: |-
-                    ExecutionID is a unique identifier for this release execution lifecycle
-                    Used for correlating all traces/events for a single release deployment from start to finish
-                    The trace ID is deterministically derived from this execution ID
-                  type: string
-                executionStartTime:
-                  description:
-                    ExecutionStartTime is when the release actually started
-                    executing (transitioned to Running)
-                  format: date-time
-                  type: string
-                isFullRelease:
-                  description:
-                    IsFullRelease indicates whether this is a full release
-                    (no targeted resources)
-                  type: boolean
-                lockedResources:
-                  description:
-                    LockedResources lists resources currently locked by this
-                    release
-                  items:
-                    description:
-                      TargetResource defines a resource to target during
-                      terraform operations
-                    properties:
-                      name:
-                        description: Name of the resource
-                        type: string
-                      type:
-                        description: Type of the resource
-                        type: string
-                    required:
-                      - name
-                      - type
-                    type: object
-                  type: array
-                message:
-                  description:
-                    Message provides additional information about the current
-                    status
-                  type: string
-                parallelReleases:
-                  description:
-                    ParallelReleases lists other releases running in parallel
-                    in same environment
-                  items:
-                    type: string
-                  type: array
-                phase:
-                  description: Phase represents the current overall phase of the release
-                  enum:
-                    - Pending
-                    - AcquiringLock
-                    - Running
-                    - WaitingForApproval
-                    - Completed
-                    - Failed
-                    - Voided
-                    - Declined
-                    - Queued
-                  type: string
-                phaseStatuses:
-                  description: PhaseStatuses tracks the status of each phase
-                  items:
-                    description: PhaseStatus defines the status of an individual phase
-                    properties:
-                      approvalRequired:
-                        description:
-                          ApprovalRequired indicates if this phase needs
-                          approval
-                        type: boolean
-                      approvedAt:
-                        description: ApprovedAt timestamp when approval was granted
-                        format: date-time
-                        type: string
-                      approvedBy:
-                        description: ApprovedBy indicates who approved the phase
-                        type: string
-                      declineReason:
-                        description: DeclineReason provides the reason for decline
-                        type: string
-                      declinedAt:
-                        description: DeclinedAt timestamp when phase was declined
-                        format: date-time
-                        type: string
-                      declinedBy:
-                        description: DeclinedBy indicates who declined the phase
-                        type: string
-                      endTime:
-                        description: EndTime when the phase completed
-                        format: date-time
-                        type: string
-                      error:
-                        description: Error provides error details
-                        type: string
-                      exitCode:
-                        description: ExitCode of the phase pod container
-                        format: int32
-                        type: integer
-                      name:
-                        description: Name of the phase
-                        type: string
-                      podName:
-                        description: PodName associated with this phase
-                        type: string
-                      startTime:
-                        description: StartTime when the phase started
-                        format: date-time
-                        type: string
-                      state:
-                        description: State of the phase
-                        enum:
-                          - Pending
-                          - Running
-                          - WaitingForApproval
-                          - Completed
-                          - Failed
-                          - Voided
-                          - Declined
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                queuePosition:
-                  description:
-                    QueuePosition indicates the position in the environment
-                    queue (0 means not queued or running)
-                  minimum: 0
-                  type: integer
-                startTime:
-                  description:
-                    StartTime is when the release was created (includes queue
-                    waiting time)
-                  format: date-time
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              phase:
+                description: Phase represents the current overall phase of the release
+                enum:
+                - Pending
+                - AcquiringLock
+                - Running
+                - WaitingForApproval
+                - Completed
+                - Failed
+                - Voided
+                - Declined
+                - Queued
+                - Superseded
+                type: string
+              phaseStatuses:
+                description: PhaseStatuses tracks the status of each phase
+                items:
+                  description: PhaseStatus defines the status of an individual phase
+                  properties:
+                    approvalRequired:
+                      description: ApprovalRequired indicates if this phase needs
+                        approval
+                      type: boolean
+                    approvedAt:
+                      description: ApprovedAt timestamp when approval was granted
+                      format: date-time
+                      type: string
+                    approvedBy:
+                      description: ApprovedBy indicates who approved the phase
+                      type: string
+                    declineReason:
+                      description: DeclineReason provides the reason for decline
+                      type: string
+                    declinedAt:
+                      description: DeclinedAt timestamp when phase was declined
+                      format: date-time
+                      type: string
+                    declinedBy:
+                      description: DeclinedBy indicates who declined the phase
+                      type: string
+                    endTime:
+                      description: EndTime when the phase completed
+                      format: date-time
+                      type: string
+                    error:
+                      description: Error provides error details
+                      type: string
+                    exitCode:
+                      description: ExitCode of the phase pod container
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name of the phase
+                      type: string
+                    podName:
+                      description: PodName associated with this phase
+                      type: string
+                    startTime:
+                      description: StartTime when the phase started
+                      format: date-time
+                      type: string
+                    state:
+                      description: State of the phase
+                      enum:
+                      - Pending
+                      - Running
+                      - WaitingForApproval
+                      - Completed
+                      - Failed
+                      - Voided
+                      - Declined
+                      - Superseded
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              queuePosition:
+                description: QueuePosition indicates the position in the environment
+                  queue (0 means not queued or running)
+                minimum: 0
+                type: integer
+              startTime:
+                description: StartTime is when the release was created (includes queue
+                  waiting time)
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/iac-operator/templates/crds/iac.facets.cloud_releasetemplates.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releasetemplates.yaml
@@ -14,1806 +14,1741 @@ spec:
     singular: releasetemplate
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Base container image for terraform execution
-          jsonPath: .spec.baseImage
-          name: Base Image
-          type: string
-        - description: Version of iac-generator binary
-          jsonPath: .spec.iacGeneratorVersion
-          name: IAC Version
-          type: string
-        - description: Maximum execution timeout in seconds
-          jsonPath: .spec.timeout
-          name: Timeout
-          type: integer
-        - description: Phase names
-          jsonPath: .status.phaseNames
-          name: Phases
-          type: string
-        - description: Terraform backend S3 bucket
-          jsonPath: .spec.tfBackend.s3.bucket
-          name: Backend
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: ReleaseTemplate is the Schema for the releasetemplates API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ReleaseTemplateSpec defines the desired state of ReleaseTemplate.
-              properties:
-                baseImage:
-                  description:
-                    BaseImage is the custom image with customer-specific
-                    dependencies
-                  type: string
-                iacGeneratorURL:
-                  description:
-                    IacGeneratorURL specifies a custom URL for downloading
-                    iac-generator
-                  type: string
-                iacGeneratorVersion:
-                  description:
-                    IacGeneratorVersion specifies the version of iac-generator
-                    binary to use
-                  type: string
-                logLevel:
-                  description: |-
-                    LogLevel sets the default log level for iac-generator execution
-                    Can be overridden per-release via spec.logLevelOverride
-                  type: string
-                phases:
-                  description:
-                    Phases defines the execution phases as a list to maintain
-                    order
-                  items:
-                    description:
-                      PhaseDefinition defines a single execution phase with
-                      a name
-                    properties:
-                      commands:
-                        description: Commands to execute in this phase
-                        items:
-                          type: string
-                        type: array
-                      name:
-                        description: Name of the phase
-                        type: string
-                      terraformOptions:
-                        description: |-
-                          TerraformOptions configures Terraform CLI flags for this phase
-                          These options apply to all terraform commands in this phase
-                        properties:
-                          allowDestroy:
-                            description: |-
-                              AllowDestroy enables replacing prevent_destroy=true with prevent_destroy=false
-                              in downloaded Terraform modules. Used for destroy operations.
-                            type: boolean
-                          lockTimeout:
-                            description: |-
-                              LockTimeout sets the duration Terraform will wait to obtain a state lock
-                              Maps to -lock-timeout flag (e.g., "5m", "30s")
-                            type: string
-                          parallelism:
-                            description: |-
-                              Parallelism limits the number of concurrent operations
-                              Maps to -parallelism flag for plan/apply commands
-                            type: integer
-                          refresh:
-                            description: |-
-                              Refresh controls whether Terraform should refresh state before operations
-                              Maps to -refresh flag for plan/apply commands
-                            type: boolean
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                podSpec:
-                  description:
-                    PodSpec defines pod specifications for pods created by
-                    this template
+  - additionalPrinterColumns:
+    - description: Base container image for terraform execution
+      jsonPath: .spec.baseImage
+      name: Base Image
+      type: string
+    - description: Version of iac-generator binary
+      jsonPath: .spec.iacGeneratorVersion
+      name: IAC Version
+      type: string
+    - description: Maximum execution timeout in seconds
+      jsonPath: .spec.timeout
+      name: Timeout
+      type: integer
+    - description: Phase names
+      jsonPath: .status.phaseNames
+      name: Phases
+      type: string
+    - description: Terraform backend S3 bucket
+      jsonPath: .spec.tfBackend.s3.bucket
+      name: Backend
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ReleaseTemplate is the Schema for the releasetemplates API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReleaseTemplateSpec defines the desired state of ReleaseTemplate.
+            properties:
+              baseImage:
+                description: BaseImage is the custom image with customer-specific
+                  dependencies
+                type: string
+              iacGeneratorURL:
+                description: IacGeneratorURL specifies a custom URL for downloading
+                  iac-generator
+                type: string
+              iacGeneratorVersion:
+                description: IacGeneratorVersion specifies the version of iac-generator
+                  binary to use
+                type: string
+              logLevel:
+                description: |-
+                  LogLevel sets the default log level for iac-generator execution
+                  Can be overridden per-release via spec.logLevelOverride
+                type: string
+              phases:
+                description: Phases defines the execution phases as a list to maintain
+                  order
+                items:
+                  description: PhaseDefinition defines a single execution phase with
+                    a name
                   properties:
-                    affinity:
-                      description: Affinity defines scheduling constraints for pods
+                    commands:
+                      description: Commands to execute in this phase
+                      items:
+                        type: string
+                      type: array
+                    holdsEnvLock:
+                      description: |-
+                        HoldsEnvLock indicates whether this phase requires the environment lock.
+                        Default is true (treated as locking). Set to false on read-only phases such
+                        as `plan` so that the operator can release the environment lock while the
+                        release is parked (e.g. WaitingForApproval), allowing other releases to run.
+                      type: boolean
+                    name:
+                      description: Name of the phase
+                      type: string
+                    terraformOptions:
+                      description: |-
+                        TerraformOptions configures Terraform CLI flags for this phase
+                        These options apply to all terraform commands in this phase
                       properties:
-                        nodeAffinity:
-                          description:
-                            Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
+                        allowDestroy:
+                          description: |-
+                            AllowDestroy enables replacing prevent_destroy=true with prevent_destroy=false
+                            in downloaded Terraform modules. Used for destroy operations.
+                          type: boolean
+                        lockTimeout:
+                          description: |-
+                            LockTimeout sets the duration Terraform will wait to obtain a state lock
+                            Maps to -lock-timeout flag (e.g., "5m", "30s")
+                          type: string
+                        parallelism:
+                          description: |-
+                            Parallelism limits the number of concurrent operations
+                            Maps to -parallelism flag for plan/apply commands
+                          type: integer
+                        refresh:
+                          description: |-
+                            Refresh controls whether Terraform should refresh state before operations
+                            Maps to -refresh flag for plan/apply commands
+                          type: boolean
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              podSpec:
+                description: PodSpec defines pod specifications for pods created by
+                  this template
+                properties:
+                  affinity:
+                    description: Affinity defines scheduling constraints for pods
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
                               description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description: |-
-                                  An empty preferred scheduling term matches all objects with implicit weight 0
-                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description:
-                                      A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchFields:
-                                        description:
-                                          A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  weight:
-                                    description:
-                                      Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from its node.
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
-                                nodeSelectorTerms:
-                                  description:
-                                    Required. A list of node selector terms.
-                                    The terms are ORed.
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
-                                    description: |-
-                                      A null or empty node selector term matches no objects. The requirements of
-                                      them are ANDed.
-                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchFields:
-                                        description:
-                                          A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    type: object
-                                    x-kubernetes-map-type: atomic
+                                    type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
                               required:
-                                - nodeSelectorTerms
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be applied to pods created by this
+                      template
+                    type: object
+                  env:
+                    description: Env is a list of environment variables to set in
+                      the container
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
-                        podAffinity:
-                          description:
-                            Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description:
-                                  The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description:
-                                      Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description:
-                                              matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description:
-                                                    key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description:
-                                              matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description:
-                                                    key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
-                        podAntiAffinity:
-                          description:
-                            Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the anti-affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description:
-                                  The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description:
-                                      Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description:
-                                              matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description:
-                                                    key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description:
-                                              matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description:
-                                                    key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the anti-affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the anti-affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
+                      required:
+                      - name
                       type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description:
-                        Annotations to be applied to pods created by this
-                        template
-                      type: object
-                    env:
-                      description:
-                        Env is a list of environment variables to set in
-                        the container
-                      items:
-                        description:
-                          EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description:
-                              Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: |-
-                              Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in the container and
-                              any service environment variables. If a variable cannot be resolved,
-                              the reference in the input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                              Escaped references will never be expanded, regardless of whether the variable
-                              exists or not.
-                              Defaults to "".
-                            type: string
-                          valueFrom:
-                            description:
-                              Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    type: string
-                                  optional:
-                                    description:
-                                      Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fieldRef:
-                                description: |-
-                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                properties:
-                                  apiVersion:
-                                    description:
-                                      Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description:
-                                      Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                properties:
-                                  containerName:
-                                    description:
-                                      "Container name: required for volumes,
-                                      optional for env vars"
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: "Required: resource to select"
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secretKeyRef:
-                                description:
-                                  Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description:
-                                      The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    type: string
-                                  optional:
-                                    description:
-                                      Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    envFrom:
-                      description:
-                        EnvFrom is a list of sources to populate environment
-                        variables from
-                      items:
-                        description:
-                          EnvFromSource represents the source of a set of
-                          ConfigMaps or Secrets
-                        properties:
-                          configMapRef:
-                            description: The ConfigMap to select from
-                            properties:
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap must be defined
-                                type: boolean
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          prefix:
-                            description:
-                              Optional text to prepend to the name of each
-                              environment variable. Must be a C_IDENTIFIER.
-                            type: string
-                          secretRef:
-                            description: The Secret to select from
-                            properties:
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret must be defined
-                                type: boolean
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        type: object
-                      type: array
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels to be applied to pods created by this template
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description:
-                        NodeSelector constrains pods to nodes with matching
-                        labels
-                      type: object
-                    priorityClassName:
-                      description:
-                        PriorityClassName indicates the importance of pods
-                        relative to other pods
-                      type: string
-                    resources:
-                      description:
-                        Resources defines resource requirements and limits
-                        for pods created by this template
+                    type: array
+                  envFrom:
+                    description: EnvFrom is a list of sources to populate environment
+                      variables from
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
                       properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
-
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
-
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
-                    runtimeClassName:
-                      description:
-                        RuntimeClassName refers to a RuntimeClass object
-                        for pods
-                      type: string
-                    securityContext:
-                      description: SecurityContext defines security attributes for pods
-                      properties:
-                        appArmorProfile:
-                          description: |-
-                            appArmorProfile is the AppArmor options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
+                        configMapRef:
+                          description: The ConfigMap to select from
                           properties:
-                            localhostProfile:
+                            name:
+                              default: ""
                               description: |-
-                                localhostProfile indicates a profile loaded on the node that should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must match the loaded name of the profile.
-                                Must be set if and only if type is "Localhost".
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
-                            type:
-                              description: |-
-                                type indicates which kind of AppArmor profile will be applied.
-                                Valid options are:
-                                  Localhost - a profile pre-loaded on the node.
-                                  RuntimeDefault - the container runtime's default profile.
-                                  Unconfined - no AppArmor enforcement.
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        fsGroup:
-                          description: |-
-                            A special supplemental group that applies to all containers in a pod.
-                            Some volume types allow the Kubelet to change the ownership of that volume
-                            to be owned by the pod:
-
-                            1. The owning GID will be the FSGroup
-                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                            3. The permission bits are OR'd with rw-rw----
-
-                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: |-
-                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                            before being exposed inside Pod. This field will only apply to
-                            volume types which support fsGroup based ownership(and permissions).
-                            It will have no effect on ephemeral volume types such as: secret, configmaps
-                            and emptydir.
-                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          type: string
-                        runAsGroup:
-                          description: |-
-                            The GID to run the entrypoint of the container process.
-                            Uses runtime default if unset.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: |-
-                            Indicates that the container must run as a non-root user.
-                            If true, the Kubelet will validate the image at runtime to ensure that it
-                            does not run as UID 0 (root) and fail to start the container if it does.
-                            If unset or false, no such validation will be performed.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: |-
-                            The UID to run the entrypoint of the container process.
-                            Defaults to user specified in image metadata if unspecified.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          format: int64
-                          type: integer
-                        seLinuxChangePolicy:
-                          description: |-
-                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
-                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
-                            Valid values are "MountOption" and "Recursive".
-
-                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
-                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
-
-                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
-                            This requires all Pods that share the same volume to use the same SELinux label.
-                            It is not possible to share the same volume among privileged and unprivileged Pods.
-                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
-                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
-                            CSIDriver instance. Other volumes are always re-labelled recursively.
-                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
-
-                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                            and "Recursive" for all other volumes.
-
-                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
-
-                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          type: string
-                        seLinuxOptions:
-                          description: |-
-                            The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random SELinux context for each
-                            container.  May also be set in SecurityContext.  If set in
-                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          properties:
-                            level:
-                              description:
-                                Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description:
-                                Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description:
-                                Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description:
-                                User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: |-
-                            The seccomp options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          properties:
-                            localhostProfile:
-                              description: |-
-                                localhostProfile indicates a profile defined in a file on the node should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                Must be set if type is "Localhost". Must NOT be set for any other type.
-                              type: string
-                            type:
-                              description: |-
-                                type indicates which kind of seccomp profile will be applied.
-                                Valid options are:
-
-                                Localhost - a profile defined in a file on the node should be used.
-                                RuntimeDefault - the container runtime default profile should be used.
-                                Unconfined - no profile should be applied.
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: |-
-                            A list of groups applied to the first process run in each container, in
-                            addition to the container's primary GID and fsGroup (if specified).  If
-                            the SupplementalGroupsPolicy feature is enabled, the
-                            supplementalGroupsPolicy field determines whether these are in addition
-                            to or instead of any group memberships defined in the container image.
-                            If unspecified, no additional groups are added, though group memberships
-                            defined in the container image may still be used, depending on the
-                            supplementalGroupsPolicy field.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        supplementalGroupsPolicy:
-                          description: |-
-                            Defines how supplemental groups of the first container processes are calculated.
-                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
-                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
-                            and the container runtime must implement support for this feature.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          type: string
-                        sysctls:
-                          description: |-
-                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                            sysctls (by the container runtime) might fail to launch.
-                            Note that this field cannot be set when spec.os.name is windows.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        windowsOptions:
-                          description: |-
-                            The Windows specific settings applied to all containers.
-                            If unspecified, the options within a container's SecurityContext will be used.
-                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is linux.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: |-
-                                GMSACredentialSpec is where the GMSA admission webhook
-                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                GMSA credential spec named by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description:
-                                GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            hostProcess:
-                              description: |-
-                                HostProcess determines if a container should be run as a 'Host Process' container.
-                                All of a Pod's containers must have the same effective HostProcess value
-                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
                               type: boolean
-                            runAsUserName:
-                              description: |-
-                                The UserName in Windows to run the entrypoint of the container process.
-                                Defaults to the user specified in image metadata if unspecified.
-                                May also be set in PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext takes precedence.
-                              type: string
                           type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: Optional text to prepend to the name of each
+                            environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
                       type: object
-                    serviceAccountName:
-                      description:
-                        ServiceAccountName specifies the service account
-                        to run pods as
+                    type: array
+                  labels:
+                    additionalProperties:
                       type: string
-                    tolerations:
-                      description:
-                        Tolerations allows pods to schedule onto nodes with
-                        matching taints
-                      items:
+                    description: Labels to be applied to pods created by this template
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector constrains pods to nodes with matching
+                      labels
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName indicates the importance of pods
+                      relative to other pods
+                    type: string
+                  resources:
+                    description: Resources defines resource requirements and limits
+                      for pods created by this template
+                    properties:
+                      claims:
                         description: |-
-                          The pod this Toleration is attached to tolerates any taint that matches
-                          the triple <key,value,effect> using the matching operator <operator>.
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  runtimeClassName:
+                    description: RuntimeClassName refers to a RuntimeClass object
+                      for pods
+                    type: string
+                  securityContext:
+                    description: SecurityContext defines security attributes for pods
+                    properties:
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
                         properties:
-                          effect:
+                          localhostProfile:
                             description: |-
-                              Effect indicates the taint effect to match. Empty means match all taint effects.
-                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
                             type: string
-                          key:
+                          type:
                             description: |-
-                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
                             type: string
-                          operator:
-                            description: |-
-                              Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
-                              Exists is equivalent to wildcard for value, so that a pod can
-                              tolerate all taints of a particular category.
+                        required:
+                        - type
+                        type: object
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
-                          tolerationSeconds:
-                            description: |-
-                              TolerationSeconds represents the period of time the toleration (which must be
-                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                              it is not set, which means tolerate the taint forever (do not evict). Zero and
-                              negative values will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: |-
-                              Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
-                      type: array
-                  type: object
-                tfBackend:
-                  description: TfBackend defines the Terraform backend configuration
-                  properties:
-                    azurerm:
-                      description: AzureRM backend configuration
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if specified).  If
+                          the SupplementalGroupsPolicy feature is enabled, the
+                          supplementalGroupsPolicy field determines whether these are in addition
+                          to or instead of any group memberships defined in the container image.
+                          If unspecified, no additional groups are added, though group memberships
+                          defined in the container image may still be used, depending on the
+                          supplementalGroupsPolicy field.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                          (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                          and the container runtime must implement support for this feature.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: ServiceAccountName specifies the service account
+                      to run pods as
+                    type: string
+                  tolerations:
+                    description: Tolerations allows pods to schedule onto nodes with
+                      matching taints
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
-                        accessKey:
-                          description: AccessKey for Azure storage
-                          type: string
-                        clientID:
-                          description: ClientID for Azure service principal
-                          type: string
-                        clientSecret:
-                          description: ClientSecret for Azure service principal
-                          type: string
-                        containerName:
-                          description: ContainerName for the state blob
-                          type: string
-                        endpoint:
-                          description: Endpoint for custom Azure endpoints
-                          type: string
-                        environment:
-                          description: Environment specifies the Azure environment
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key for the state blob
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
-                        resourceGroupName:
-                          description: ResourceGroupName for the storage account
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
                           type: string
-                        sasToken:
-                          description: SASToken for Azure storage
-                          type: string
-                        storageAccountName:
-                          description: StorageAccountName for the backend
-                          type: string
-                        subscriptionID:
-                          description: SubscriptionID for Azure
-                          type: string
-                        tenantID:
-                          description: TenantID for Azure
-                          type: string
-                      required:
-                        - containerName
-                        - key
-                        - resourceGroupName
-                        - storageAccountName
-                      type: object
-                    gcs:
-                      description: GCS backend configuration
-                      properties:
-                        accessToken:
-                          description: AccessToken for GCS authentication
-                          type: string
-                        bucket:
-                          description: Bucket name for GCS backend
-                          type: string
-                        credentials:
-                          description: Credentials for GCS authentication
-                          type: string
-                        prefix:
-                          description: Prefix for the state path
-                          type: string
-                        project:
-                          description: Project specifies the GCP project
-                          type: string
-                      required:
-                        - bucket
-                      type: object
-                    local:
-                      description: Local backend configuration
-                      properties:
-                        path:
-                          description: Path for the local state file
-                          type: string
-                        workspaceDir:
-                          description: WorkspaceDir for workspace state files
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
-                    pg:
-                      description: PG backend configuration
-                      properties:
-                        connStr:
-                          description:
-                            ConnStr is the connection string for Postgres
-                            database
-                          type: string
-                        schemaName:
-                          description: SchemaName where state is stored
-                          type: string
-                        skipIndexCreation:
-                          description:
-                            SkipIndexCreation skips index creation if it
-                            already exists
-                          type: boolean
-                        skipTableCreation:
-                          description:
-                            SkipTableCreation skips table creation if it
-                            already exists
-                          type: boolean
-                      required:
-                        - connStr
-                      type: object
-                    s3:
-                      description: S3 backend configuration
-                      properties:
-                        bucket:
-                          description: Bucket name for S3 backend
-                          type: string
-                        dynamodbTable:
-                          description: DynamoDB table for state locking
-                          type: string
-                        encrypt:
-                          description:
-                            Encrypt enables server-side encryption of the
-                            state file
-                          type: boolean
-                        externalID:
-                          description: ExternalID for the assumed role
-                          type: string
-                        key:
-                          description: Key for the state file
-                          type: string
-                        kmsKeyID:
-                          description: KMSKeyID specifies the KMS key for encryption
-                          type: string
-                        profile:
-                          description: Profile specifies the AWS CLI profile
-                          type: string
-                        region:
-                          description: AWS Region
-                          type: string
-                        roleArn:
-                          description: RoleARN specifies an IAM role to assume
-                          type: string
-                        sessionName:
-                          description: SessionName for the assumed role session
-                          type: string
-                        workspaceKeyPrefix:
-                          description: WorkspaceKeyPrefix for S3 key prefix
-                          type: string
-                      required:
-                        - bucket
-                        - key
-                        - region
-                      type: object
-                  type: object
-                timeout:
-                  description: Timeout in seconds, only applicable to main processes
-                  minimum: 1
-                  type: integer
-              required:
-                - baseImage
-                - iacGeneratorVersion
-                - phases
-                - tfBackend
-                - timeout
-              type: object
-            status:
-              description: ReleaseTemplateStatus defines the observed state of ReleaseTemplate.
-              properties:
-                phaseNames:
-                  description:
-                    PhaseNames contains comma-separated list of phase names
-                    for display purposes
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                type: object
+              tfBackend:
+                description: TfBackend defines the Terraform backend configuration
+                properties:
+                  azurerm:
+                    description: AzureRM backend configuration
+                    properties:
+                      accessKey:
+                        description: AccessKey for Azure storage
+                        type: string
+                      clientID:
+                        description: ClientID for Azure service principal
+                        type: string
+                      clientSecret:
+                        description: ClientSecret for Azure service principal
+                        type: string
+                      containerName:
+                        description: ContainerName for the state blob
+                        type: string
+                      endpoint:
+                        description: Endpoint for custom Azure endpoints
+                        type: string
+                      environment:
+                        description: Environment specifies the Azure environment
+                        type: string
+                      key:
+                        description: Key for the state blob
+                        type: string
+                      resourceGroupName:
+                        description: ResourceGroupName for the storage account
+                        type: string
+                      sasToken:
+                        description: SASToken for Azure storage
+                        type: string
+                      storageAccountName:
+                        description: StorageAccountName for the backend
+                        type: string
+                      subscriptionID:
+                        description: SubscriptionID for Azure
+                        type: string
+                      tenantID:
+                        description: TenantID for Azure
+                        type: string
+                    required:
+                    - containerName
+                    - key
+                    - resourceGroupName
+                    - storageAccountName
+                    type: object
+                  gcs:
+                    description: GCS backend configuration
+                    properties:
+                      accessToken:
+                        description: AccessToken for GCS authentication
+                        type: string
+                      bucket:
+                        description: Bucket name for GCS backend
+                        type: string
+                      credentials:
+                        description: Credentials for GCS authentication
+                        type: string
+                      prefix:
+                        description: Prefix for the state path
+                        type: string
+                      project:
+                        description: Project specifies the GCP project
+                        type: string
+                    required:
+                    - bucket
+                    type: object
+                  local:
+                    description: Local backend configuration
+                    properties:
+                      path:
+                        description: Path for the local state file
+                        type: string
+                      workspaceDir:
+                        description: WorkspaceDir for workspace state files
+                        type: string
+                    type: object
+                  pg:
+                    description: PG backend configuration
+                    properties:
+                      connStr:
+                        description: ConnStr is the connection string for Postgres
+                          database
+                        type: string
+                      schemaName:
+                        description: SchemaName where state is stored
+                        type: string
+                      skipIndexCreation:
+                        description: SkipIndexCreation skips index creation if it
+                          already exists
+                        type: boolean
+                      skipTableCreation:
+                        description: SkipTableCreation skips table creation if it
+                          already exists
+                        type: boolean
+                    required:
+                    - connStr
+                    type: object
+                  s3:
+                    description: S3 backend configuration
+                    properties:
+                      bucket:
+                        description: Bucket name for S3 backend
+                        type: string
+                      dynamodbTable:
+                        description: DynamoDB table for state locking
+                        type: string
+                      encrypt:
+                        description: Encrypt enables server-side encryption of the
+                          state file
+                        type: boolean
+                      externalID:
+                        description: ExternalID for the assumed role
+                        type: string
+                      key:
+                        description: Key for the state file
+                        type: string
+                      kmsKeyID:
+                        description: KMSKeyID specifies the KMS key for encryption
+                        type: string
+                      profile:
+                        description: Profile specifies the AWS CLI profile
+                        type: string
+                      region:
+                        description: AWS Region
+                        type: string
+                      roleArn:
+                        description: RoleARN specifies an IAM role to assume
+                        type: string
+                      sessionName:
+                        description: SessionName for the assumed role session
+                        type: string
+                      workspaceKeyPrefix:
+                        description: WorkspaceKeyPrefix for S3 key prefix
+                        type: string
+                    required:
+                    - bucket
+                    - key
+                    - region
+                    type: object
+                type: object
+              timeout:
+                description: Timeout in seconds, only applicable to main processes
+                minimum: 1
+                type: integer
+            required:
+            - baseImage
+            - iacGeneratorVersion
+            - phases
+            - tfBackend
+            - timeout
+            type: object
+          status:
+            description: ReleaseTemplateStatus defines the observed state of ReleaseTemplate.
+            properties:
+              phaseNames:
+                description: PhaseNames contains comma-separated list of phase names
+                  for display purposes
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: facetscloud/iac-operator
   pullPolicy: IfNotPresent
-  tag: "operator-v0.1.17"
+  tag: "operator-v0.1.18"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

Mirrors [iac-generator PR #91](https://github.com/Facets-cloud/iac-generator/pull/91) (phase-scoped env lock + `Superseded` phase + durable approval).

### Schema changes synced

- **ReleaseTemplate**: `phases[].holdsEnvLock` (`*bool`, default true). Read-only phases can opt out so the operator skips the env-lock entirely during that phase's pod execution AND drops the lock during any approval park that follows. Default-true preserves the pre-feature serialization for every existing template.
- **Release**: `status.phase` and `status.phaseStatuses[].state` enums gain `Superseded`. Newer releases on the same env supersede parked-with-lock-dropped siblings. `HandleApproval` returns HTTP 409 (`ErrSuperseded`) for releases that lost the lock during the approval wait.

### Version bumps

| File | Before | After |
|---|---|---|
| `Chart.yaml` `version` | `0.1.17` | `0.1.18` |
| `Chart.yaml` `appVersion` | `"0.1.17"` | `"0.1.18"` |
| `values.yaml` `image.tag` | `"operator-v0.1.17"` | `"operator-v0.1.18"` |

### Notes on the bulk diff

CRD YAMLs are now copied straight from `iac-generator/operator/config/crd/bases/` (controller-gen output). The 5800-line diff is overwhelmingly YAML indentation drift from prior hand-formatting; the actual schema delta is **one new `holdsEnvLock` field** + **two `Superseded` enum entries**. Future syncs that track controller-gen output directly will produce small diffs.

## Test plan

- [x] `helm lint iac-operator/` — passes.
- [x] `helm template test iac-operator/` — renders without error; new `holdsEnvLock` field + `Superseded` enum entries present in output.
- [ ] Install chart against a dev cluster, apply a ReleaseTemplate with `holdsEnvLock: false` on a `plan` phase; confirm CRD validation accepts it.
- [ ] Apply a Release CR that transitions to `Superseded`; confirm `status.phase` enum accepts the value.

## Related

- iac-generator: tag `operator-v0.1.18` (this PR uses that image)
- iac-generator binary: tag `v0.1.26` (separate, no behaviour shift for the helm chart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)