### PR TITLE
Bump iac-operator to operator-v0.1.19

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.18
-appVersion: "0.1.18"
+version: 0.1.19
+appVersion: "0.1.19"
 keywords:
   - iac
   - terraform

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: facetscloud/iac-operator
   pullPolicy: IfNotPresent
-  tag: "operator-v0.1.18"
+  tag: "operator-v0.1.19"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## What
Bumps the `iac-operator` chart to the `operator-v0.1.19` release.

- `Chart.yaml`: `version` and `appVersion` `0.1.18` → `0.1.19`
- `values.yaml`: image `tag` `operator-v0.1.18` → `operator-v0.1.19`

## Why
Picks up the operator's new `GET /version` endpoint (port 9090) with ldflags build stamping — see iac-generator [#92](https://github.com/Facets-cloud/iac-generator/pull/92), released as tag `operator-v0.1.19`.

## CRDs
**No CRD changes.** `git diff operator-v0.1.18..operator-v0.1.19` on the operator shows zero changes under `config/crd` or `api/` — the release only touched the API server, `cmd/main.go`, Dockerfile and Makefile. `templates/crds/` left untouched.

## Testing
- `helm lint iac-operator` → `1 chart(s) linted, 0 chart(s) failed`
- Image `facetscloud/iac-operator:operator-v0.1.19` is being built/pushed by the operator release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)