### PR TITLE
Wire release-sweeper flags into iac-operator chart

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.19
+version: 0.1.20
 appVersion: "0.1.19"
 keywords:
   - iac

--- a/iac-operator/templates/deployment.yaml
+++ b/iac-operator/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
           {{- if .Values.operator.watchNamespace }}
           - --namespace={{ .Values.operator.watchNamespace }}
           {{- end }}
+          {{- if .Values.operator.releaseSweeper.enabled }}
+          - --release-sweeper-enabled=true
+          - --release-sweeper-interval={{ .Values.operator.releaseSweeper.interval }}
+          - --release-sweeper-max-per-env={{ .Values.operator.releaseSweeper.maxReleasesPerEnv }}
+          - --release-sweeper-trigger-threshold={{ .Values.operator.releaseSweeper.triggerThreshold }}
+          - --release-sweeper-run-on-startup={{ .Values.operator.releaseSweeper.runOnStartup }}
+          {{- end }}
         env:
         - name: OPERATOR_NAMESPACE
           valueFrom:

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -27,6 +27,23 @@ operator:
     resourceName: iac-operator-leader
     resourceNamespace: "" # Uses release namespace if empty
 
+  # Release-CR retention sweeper.
+  # Periodically prunes terminal Release CRs per environment so the cluster
+  # does not accumulate thousands of completed Release objects.
+  # Disabled by default — opt in per cluster.
+  releaseSweeper:
+    enabled: false
+    # How often the sweeper runs.
+    interval: 15m
+    # Per-environment retention cap: sweeper prunes terminal Release CRs
+    # down to this count.
+    maxReleasesPerEnv: 10
+    # High-water mark: sweeper does no work for an environment whose terminal
+    # release count is at or below this.
+    triggerThreshold: 15
+    # If true, run one sweep at operator startup before the first interval.
+    runOnStartup: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Problem
The operator ships a periodic **Release-CR retention sweeper**, gated behind `--release-sweeper-enabled` (`cmd/main.go`, default off). The Helm chart never rendered any of the sweeper flags, so the sweeper **could not be enabled on any chart-deployed cluster**. Result: terminal `Release` CRs accumulate without bound.

Observed on `capillary-cloud-root` (running `operator-v0.1.19`): **3530 Release CRs** in the `facets` namespace, zero sweeper log lines, and live deployment args containing no `--release-sweeper-*` flag.

## Fix
Expose the sweeper via the chart:
- **`values.yaml`** — new `operator.releaseSweeper` block (`enabled`, `interval`, `maxReleasesPerEnv`, `triggerThreshold`, `runOnStartup`). Disabled by default; opt in per cluster.
- **`templates/deployment.yaml`** — render the operator flags when `operator.releaseSweeper.enabled`:
  `--release-sweeper-enabled` / `-interval` / `-max-per-env` / `-trigger-threshold` / `-run-on-startup` (names match `cmd/main.go`).
- **`Chart.yaml`** — `version` `0.1.19` → `0.1.20`. `appVersion` unchanged (`0.1.19`): no operator binary change, only chart wiring.

## Testing
- `helm lint iac-operator` → `0 chart(s) failed`.
- `helm template` with sweeper **disabled** (default) → no sweeper flags rendered.
- `helm template --set operator.releaseSweeper.enabled=true --set operator.releaseSweeper.maxReleasesPerEnv=50` → all five flags render, override applied.

## Enabling on a cluster
Set `operator.releaseSweeper.enabled=true` (tune `maxReleasesPerEnv`) in the release values.

⚠️ The sweeper is **destructive** — it prunes terminal Release CRs down to `maxReleasesPerEnv` per environment for any env above `triggerThreshold`. On a cluster with thousands of CRs, first enable with a deliberately high `maxReleasesPerEnv` and `runOnStartup=false` to observe one interval before tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)