### PR TITLE
iac-operator: grant manager role RBAC on projecttypes

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "0.1.20"
 keywords:
   - iac

--- a/iac-operator/templates/role.yaml
+++ b/iac-operator/templates/role.yaml
@@ -162,4 +162,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - iac.facets.cloud
+  resources:
+  - projecttypes
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}


### PR DESCRIPTION
## Problem
Releases that reference a `projectTypeRef` stall in `Running`. The operator log shows:

```
projecttypes.iac.facets.cloud is forbidden: User "system:serviceaccount:facets:iac-operator"
cannot list resource "projecttypes" in API group "iac.facets.cloud" at the cluster scope
```

The chart `ClusterRole` (templates/role.yaml) covered `releases` + `releasetemplates` but never got the `projecttypes` rule when the ProjectType CRD was added, so the operator's ProjectType informer can't list → cache never syncs → reconcile blocked.

The operator's own generated RBAC (`config/rbac/role.yaml`) already had this rule; only the hand-maintained chart role was missing it.

## Fix
Add `projecttypes: [get, list, watch]` to the manager ClusterRole (matches the operator's `+kubebuilder:rbac` marker).

Already hot-patched on the affected cluster to unblock; this makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)