### PR TITLE
secret-copier: type-aware dockerconfig patching (never delete target)

### DIFF
--- a/secret-copier/Chart.yaml
+++ b/secret-copier/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: secret-copier
-version: 1.0.2
-description: Used to copy secrets from default namespace to all other namespaces.
+version: 1.1.0
+description: Copies labelled secrets from the default namespace to all other namespaces, with type-aware (dockercfg/dockerconfigjson) patching that never deletes the target.

--- a/secret-copier/README.md
+++ b/secret-copier/README.md
@@ -1,71 +1,99 @@
-## example with helm chart
+# secret-copier
 
-A helm version of [102-monitor-namespaces](https://github.com/flant/shell-operator/tree/master/examples/102-monitor-namespaces) example. It uses `ghcr.io/flant/shell-operator:latest` image in chart template to run shell-operator and a ConfigMap as a storage for hooks.
+Replicates labelled secrets from the `default` namespace into every other active
+namespace, and keeps them in sync. Built for fanning out image **pull secrets**
+(docker registry credentials) so pods in any namespace can pull images.
 
+It runs [flant/shell-operator](https://github.com/flant/shell-operator) with the
+hooks stored in a ConfigMap (`templates/hook-configmap.yaml`, sourced from
+`.Values.Config` in `values.yaml`).
 
-### Run
+## What it does
 
-Tiller should be configured with ServiceAccount to be able to install releases in different namespaces:
-
-```
-kubectl create serviceaccount tiller --namespace kube-system 
-
-kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-
-helm init --service-account tiller
-```
-
-Install example to ns/example-helm:
+A secret in `default` is replicated to all other namespaces when it carries the
+label:
 
 ```
-helm install . --namespace example-helm --name example-helm
+secret-copier: yes
 ```
 
-### See hook in action
+Four hooks drive the sync:
 
-1. Create ns/foobar to trigger a hook:
+| Hook | Trigger | Action |
+|------|---------|--------|
+| `add_or_update_secret` | labelled secret in `default` Added/Modified | copy to every other active namespace |
+| `create_namespace` | any namespace Added | copy all labelled `default` secrets into it |
+| `schedule_sync_secret` | cron `0 3 * * *` | reconcile all labelled secrets into all namespaces |
+| `delete_secret` | labelled secret in `default` Deleted | **no-op** (targets are intentionally left in place) |
 
-```
-kubectl create ns foobar
-```
+## Type-aware copy (why this is not a plain `kubectl apply`)
 
-See in logs that hook was run:
+A Secret's `.type` is **immutable**. Docker pull secrets exist in two type
+variants that hold the same credentials in different shapes:
 
-```
-kubectl -n example-helm logs deploy/shell-operator
+| type | data key | payload |
+|------|----------|---------|
+| `kubernetes.io/dockercfg` (older kubectl) | `.dockercfg` | `{ "<registry>": {...} }` |
+| `kubernetes.io/dockerconfigjson` (newer kubectl) | `.dockerconfigjson` | `{ "auths": { "<registry>": {...} } }` |
 
-...
-Namespace foobar was created
-...
-```
+When a source secret's type differs from an existing target's type, a naive
+`kubectl apply` fails on the immutable-field conflict and the copy silently
+breaks — which caused a production pull-secret outage.
 
-2. Delete ns/foobar to trigger a hook:
+The copier therefore resolves each target case explicitly, and **never deletes**
+a target (delete+recreate would open a window with no pull secret):
 
-```
-kubectl create ns foobar
-```
+1. **Target missing** → create it (carries the source type).
+2. **Same type** → `apply` (only `.data` changes).
+   - Target `immutable: true` → skip + warn.
+3. **Type mismatch**, `dockercfg ↔ dockerconfigjson` → **patch `.data` only**:
+   convert the payload into the target type's key/shape, drop the stale key,
+   leave `.type` untouched.
+   - Target `immutable: true` → skip + warn (cannot patch).
+   - Any other (non-convertible) type mismatch → skip + warn.
 
-See in logs that hook was run:
+Only `dockercfg ↔ dockerconfigjson` is convertible — those two encode the same
+data. All other type mismatches are skipped, never guessed.
 
-```
-kubectl -n example-helm logs deploy/shell-operator
+## Observability
 
-...
-Namespace foobar was deleted
-...
-```
-
-### Make changes
-
-Deployment/shell-operator has annotation with checksum of hook file, so after editing namespace-hook.sh release can be upgraded without additional kubectl commands:
-
-```
-helm upgrade example-helm . --namespace example-helm
-```
-
-### Cleanup
+Every action logs a `secret-copier:` line to the shell-operator pod's stdout:
 
 ```
-helm delete --purge example-helm
-kubectl delete ns/example-helm
+kubectl -n <release-namespace> logs deploy/<release-name>
 ```
+
+- `created <ns>/<name> (type=...)`
+- `updated <ns>/<name> (type=...)`
+- `converted <ns>/<name> data (<src> -> target type <dst>; type preserved, data patched)`
+- `SKIP <ns>/<name> ...` (immutable / non-convertible / empty payload) — on stderr
+- `ERROR failed to patch <ns>/<name> ...` — on stderr
+
+## Install
+
+```
+helm install secret-copier ./secret-copier --namespace <ns> --create-namespace
+```
+
+Then label a pull secret in `default` to start replication:
+
+```
+kubectl -n default label secret <name> secret-copier=yes
+```
+
+## Upgrade
+
+The shell-operator Deployment is annotated with a checksum of the hook
+ConfigMap, so editing hooks in `values.yaml` and running `helm upgrade` rolls
+the operator automatically:
+
+```
+helm upgrade secret-copier ./secret-copier --namespace <ns>
+```
+
+## Note
+
+This chart is a homegrown equivalent of maintained cross-namespace secret
+replicators such as [emberstack/kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector)
+and [kubed](https://github.com/kubeops/kubed). Consider them if you want an
+off-the-shelf, patch-based replicator instead of maintaining these hooks.

--- a/secret-copier/values.yaml
+++ b/secret-copier/values.yaml
@@ -22,8 +22,15 @@ Config:
       name=$(jq -r '.metadata.name' <<< "$object")
       src_type=$(jq -r '.type // ""' <<< "$object")
 
+      # Fetch target. --ignore-not-found => empty stdout + rc 0 when absent; a non-zero rc means a
+      # real API error, in which case skip (do NOT fall through to apply, which would silently no-op
+      # on a mismatched-type target and mislabel it "created").
+      if ! existing=$(kubectl -n "$ns" get secret "$name" -o json --ignore-not-found 2>/dev/null) ; then
+        echo "secret-copier: ERROR get failed for $ns/$name, skipping" >&2
+        return
+      fi
+
       # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
-      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
       if [[ -z "$existing" ]] ; then
         kubectl apply -f - <<< "$object" >/dev/null
         echo "secret-copier: created $ns/$name (type=$src_type)"
@@ -152,8 +159,15 @@ Config:
       name=$(jq -r '.metadata.name' <<< "$object")
       src_type=$(jq -r '.type // ""' <<< "$object")
 
+      # Fetch target. --ignore-not-found => empty stdout + rc 0 when absent; a non-zero rc means a
+      # real API error, in which case skip (do NOT fall through to apply, which would silently no-op
+      # on a mismatched-type target and mislabel it "created").
+      if ! existing=$(kubectl -n "$ns" get secret "$name" -o json --ignore-not-found 2>/dev/null) ; then
+        echo "secret-copier: ERROR get failed for $ns/$name, skipping" >&2
+        return
+      fi
+
       # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
-      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
       if [[ -z "$existing" ]] ; then
         kubectl apply -f - <<< "$object" >/dev/null
         echo "secret-copier: created $ns/$name (type=$src_type)"
@@ -266,8 +280,15 @@ Config:
       name=$(jq -r '.metadata.name' <<< "$object")
       src_type=$(jq -r '.type // ""' <<< "$object")
 
+      # Fetch target. --ignore-not-found => empty stdout + rc 0 when absent; a non-zero rc means a
+      # real API error, in which case skip (do NOT fall through to apply, which would silently no-op
+      # on a mismatched-type target and mislabel it "created").
+      if ! existing=$(kubectl -n "$ns" get secret "$name" -o json --ignore-not-found 2>/dev/null) ; then
+        echo "secret-copier: ERROR get failed for $ns/$name, skipping" >&2
+        return
+      fi
+
       # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
-      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
       if [[ -z "$existing" ]] ; then
         kubectl apply -f - <<< "$object" >/dev/null
         echo "secret-copier: created $ns/$name (type=$src_type)"
@@ -393,8 +414,15 @@ Config:
       name=$(jq -r '.metadata.name' <<< "$object")
       src_type=$(jq -r '.type // ""' <<< "$object")
 
+      # Fetch target. --ignore-not-found => empty stdout + rc 0 when absent; a non-zero rc means a
+      # real API error, in which case skip (do NOT fall through to apply, which would silently no-op
+      # on a mismatched-type target and mislabel it "created").
+      if ! existing=$(kubectl -n "$ns" get secret "$name" -o json --ignore-not-found 2>/dev/null) ; then
+        echo "secret-copier: ERROR get failed for $ns/$name, skipping" >&2
+        return
+      fi
+
       # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
-      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
       if [[ -z "$existing" ]] ; then
         kubectl apply -f - <<< "$object" >/dev/null
         echo "secret-copier: created $ns/$name (type=$src_type)"

--- a/secret-copier/values.yaml
+++ b/secret-copier/values.yaml
@@ -16,7 +16,65 @@ Config:
 
     function kubectl::replace_or_create() {
       object=$(cat)
-      kubectl apply -f - <<< "$object" >/dev/null
+      local ns name src_type existing dst_type dst_immutable key other decoded patch
+
+      ns=$(jq -r '.metadata.namespace' <<< "$object")
+      name=$(jq -r '.metadata.name' <<< "$object")
+      src_type=$(jq -r '.type // ""' <<< "$object")
+
+      # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
+      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
+      if [[ -z "$existing" ]] ; then
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: created $ns/$name (type=$src_type)"
+        return
+      fi
+
+      dst_type=$(jq -r '.type // ""' <<< "$existing")
+      dst_immutable=$(jq -r '.immutable // false' <<< "$existing")
+
+      # Same type -> apply is safe (only .data is mutated, .type unchanged).
+      if [[ "$src_type" == "$dst_type" ]] ; then
+        if [[ "$dst_immutable" == "true" ]] ; then
+          echo "secret-copier: SKIP $ns/$name is immutable, cannot update data" >&2
+          return
+        fi
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: updated $ns/$name (type=$dst_type)"
+        return
+      fi
+
+      # Type mismatch: .type is immutable, so we must NOT send it. Patch .data only.
+      # Deleting + recreating would open a window with no pull secret -> outage; do not do that.
+      if [[ "$dst_immutable" == "true" ]] ; then
+        echo "secret-copier: SKIP $ns/$name type mismatch ($src_type -> $dst_type) but target immutable" >&2
+        return
+      fi
+
+      # Only dockercfg <-> dockerconfigjson is safely convertible (data key + payload shape differ).
+      if [[ "$dst_type" == "kubernetes.io/dockerconfigjson" && "$src_type" == "kubernetes.io/dockercfg" ]] ; then
+        key=".dockerconfigjson" ; other=".dockercfg"
+        decoded=$(jq -r '.data[".dockercfg"]' <<< "$object" | base64 -d | jq -c '{auths: .}' | base64 | tr -d '\n')
+      elif [[ "$dst_type" == "kubernetes.io/dockercfg" && "$src_type" == "kubernetes.io/dockerconfigjson" ]] ; then
+        key=".dockercfg" ; other=".dockerconfigjson"
+        decoded=$(jq -r '.data[".dockerconfigjson"]' <<< "$object" | base64 -d | jq -c '.auths' | base64 | tr -d '\n')
+      else
+        echo "secret-copier: SKIP $ns/$name non-convertible type mismatch ($src_type -> $dst_type)" >&2
+        return
+      fi
+
+      if [[ -z "$decoded" || "$decoded" == "null" ]] ; then
+        echo "secret-copier: SKIP $ns/$name conversion produced empty payload" >&2
+        return
+      fi
+
+      # Patch .data only: set the target-type key, drop the stale opposite key, leave .type untouched.
+      patch=$(jq -cn --arg k "$key" --arg o "$other" --arg v "$decoded" '{data: {($k): $v, ($o): null}}')
+      if kubectl -n "$ns" patch secret "$name" --type merge -p "$patch" >/dev/null ; then
+        echo "secret-copier: converted $ns/$name data ($src_type -> target type $dst_type; type preserved, data patched)"
+      else
+        echo "secret-copier: ERROR failed to patch $ns/$name on type mismatch ($src_type -> $dst_type)" >&2
+      fi
     }
 
     hook::config() {
@@ -88,7 +146,65 @@ Config:
 
     function kubectl::replace_or_create() {
       object=$(cat)
-      kubectl apply -f - <<< "$object" >/dev/null
+      local ns name src_type existing dst_type dst_immutable key other decoded patch
+
+      ns=$(jq -r '.metadata.namespace' <<< "$object")
+      name=$(jq -r '.metadata.name' <<< "$object")
+      src_type=$(jq -r '.type // ""' <<< "$object")
+
+      # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
+      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
+      if [[ -z "$existing" ]] ; then
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: created $ns/$name (type=$src_type)"
+        return
+      fi
+
+      dst_type=$(jq -r '.type // ""' <<< "$existing")
+      dst_immutable=$(jq -r '.immutable // false' <<< "$existing")
+
+      # Same type -> apply is safe (only .data is mutated, .type unchanged).
+      if [[ "$src_type" == "$dst_type" ]] ; then
+        if [[ "$dst_immutable" == "true" ]] ; then
+          echo "secret-copier: SKIP $ns/$name is immutable, cannot update data" >&2
+          return
+        fi
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: updated $ns/$name (type=$dst_type)"
+        return
+      fi
+
+      # Type mismatch: .type is immutable, so we must NOT send it. Patch .data only.
+      # Deleting + recreating would open a window with no pull secret -> outage; do not do that.
+      if [[ "$dst_immutable" == "true" ]] ; then
+        echo "secret-copier: SKIP $ns/$name type mismatch ($src_type -> $dst_type) but target immutable" >&2
+        return
+      fi
+
+      # Only dockercfg <-> dockerconfigjson is safely convertible (data key + payload shape differ).
+      if [[ "$dst_type" == "kubernetes.io/dockerconfigjson" && "$src_type" == "kubernetes.io/dockercfg" ]] ; then
+        key=".dockerconfigjson" ; other=".dockercfg"
+        decoded=$(jq -r '.data[".dockercfg"]' <<< "$object" | base64 -d | jq -c '{auths: .}' | base64 | tr -d '\n')
+      elif [[ "$dst_type" == "kubernetes.io/dockercfg" && "$src_type" == "kubernetes.io/dockerconfigjson" ]] ; then
+        key=".dockercfg" ; other=".dockerconfigjson"
+        decoded=$(jq -r '.data[".dockerconfigjson"]' <<< "$object" | base64 -d | jq -c '.auths' | base64 | tr -d '\n')
+      else
+        echo "secret-copier: SKIP $ns/$name non-convertible type mismatch ($src_type -> $dst_type)" >&2
+        return
+      fi
+
+      if [[ -z "$decoded" || "$decoded" == "null" ]] ; then
+        echo "secret-copier: SKIP $ns/$name conversion produced empty payload" >&2
+        return
+      fi
+
+      # Patch .data only: set the target-type key, drop the stale opposite key, leave .type untouched.
+      patch=$(jq -cn --arg k "$key" --arg o "$other" --arg v "$decoded" '{data: {($k): $v, ($o): null}}')
+      if kubectl -n "$ns" patch secret "$name" --type merge -p "$patch" >/dev/null ; then
+        echo "secret-copier: converted $ns/$name data ($src_type -> target type $dst_type; type preserved, data patched)"
+      else
+        echo "secret-copier: ERROR failed to patch $ns/$name on type mismatch ($src_type -> $dst_type)" >&2
+      fi
     }
 
     hook::config() {
@@ -144,7 +260,65 @@ Config:
 
     function kubectl::replace_or_create() {
       object=$(cat)
-      kubectl apply -f - <<< "$object" >/dev/null
+      local ns name src_type existing dst_type dst_immutable key other decoded patch
+
+      ns=$(jq -r '.metadata.namespace' <<< "$object")
+      name=$(jq -r '.metadata.name' <<< "$object")
+      src_type=$(jq -r '.type // ""' <<< "$object")
+
+      # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
+      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
+      if [[ -z "$existing" ]] ; then
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: created $ns/$name (type=$src_type)"
+        return
+      fi
+
+      dst_type=$(jq -r '.type // ""' <<< "$existing")
+      dst_immutable=$(jq -r '.immutable // false' <<< "$existing")
+
+      # Same type -> apply is safe (only .data is mutated, .type unchanged).
+      if [[ "$src_type" == "$dst_type" ]] ; then
+        if [[ "$dst_immutable" == "true" ]] ; then
+          echo "secret-copier: SKIP $ns/$name is immutable, cannot update data" >&2
+          return
+        fi
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: updated $ns/$name (type=$dst_type)"
+        return
+      fi
+
+      # Type mismatch: .type is immutable, so we must NOT send it. Patch .data only.
+      # Deleting + recreating would open a window with no pull secret -> outage; do not do that.
+      if [[ "$dst_immutable" == "true" ]] ; then
+        echo "secret-copier: SKIP $ns/$name type mismatch ($src_type -> $dst_type) but target immutable" >&2
+        return
+      fi
+
+      # Only dockercfg <-> dockerconfigjson is safely convertible (data key + payload shape differ).
+      if [[ "$dst_type" == "kubernetes.io/dockerconfigjson" && "$src_type" == "kubernetes.io/dockercfg" ]] ; then
+        key=".dockerconfigjson" ; other=".dockercfg"
+        decoded=$(jq -r '.data[".dockercfg"]' <<< "$object" | base64 -d | jq -c '{auths: .}' | base64 | tr -d '\n')
+      elif [[ "$dst_type" == "kubernetes.io/dockercfg" && "$src_type" == "kubernetes.io/dockerconfigjson" ]] ; then
+        key=".dockercfg" ; other=".dockerconfigjson"
+        decoded=$(jq -r '.data[".dockerconfigjson"]' <<< "$object" | base64 -d | jq -c '.auths' | base64 | tr -d '\n')
+      else
+        echo "secret-copier: SKIP $ns/$name non-convertible type mismatch ($src_type -> $dst_type)" >&2
+        return
+      fi
+
+      if [[ -z "$decoded" || "$decoded" == "null" ]] ; then
+        echo "secret-copier: SKIP $ns/$name conversion produced empty payload" >&2
+        return
+      fi
+
+      # Patch .data only: set the target-type key, drop the stale opposite key, leave .type untouched.
+      patch=$(jq -cn --arg k "$key" --arg o "$other" --arg v "$decoded" '{data: {($k): $v, ($o): null}}')
+      if kubectl -n "$ns" patch secret "$name" --type merge -p "$patch" >/dev/null ; then
+        echo "secret-copier: converted $ns/$name data ($src_type -> target type $dst_type; type preserved, data patched)"
+      else
+        echo "secret-copier: ERROR failed to patch $ns/$name on type mismatch ($src_type -> $dst_type)" >&2
+      fi
     }
 
     hook::config() {
@@ -213,7 +387,65 @@ Config:
 
     function kubectl::replace_or_create() {
       object=$(cat)
-      kubectl apply -f - <<< "$object" >/dev/null
+      local ns name src_type existing dst_type dst_immutable key other decoded patch
+
+      ns=$(jq -r '.metadata.namespace' <<< "$object")
+      name=$(jq -r '.metadata.name' <<< "$object")
+      src_type=$(jq -r '.type // ""' <<< "$object")
+
+      # Target does not exist yet -> create it (carries the source type). Safe for fresh namespaces.
+      existing=$(kubectl -n "$ns" get secret "$name" -o json 2>/dev/null)
+      if [[ -z "$existing" ]] ; then
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: created $ns/$name (type=$src_type)"
+        return
+      fi
+
+      dst_type=$(jq -r '.type // ""' <<< "$existing")
+      dst_immutable=$(jq -r '.immutable // false' <<< "$existing")
+
+      # Same type -> apply is safe (only .data is mutated, .type unchanged).
+      if [[ "$src_type" == "$dst_type" ]] ; then
+        if [[ "$dst_immutable" == "true" ]] ; then
+          echo "secret-copier: SKIP $ns/$name is immutable, cannot update data" >&2
+          return
+        fi
+        kubectl apply -f - <<< "$object" >/dev/null
+        echo "secret-copier: updated $ns/$name (type=$dst_type)"
+        return
+      fi
+
+      # Type mismatch: .type is immutable, so we must NOT send it. Patch .data only.
+      # Deleting + recreating would open a window with no pull secret -> outage; do not do that.
+      if [[ "$dst_immutable" == "true" ]] ; then
+        echo "secret-copier: SKIP $ns/$name type mismatch ($src_type -> $dst_type) but target immutable" >&2
+        return
+      fi
+
+      # Only dockercfg <-> dockerconfigjson is safely convertible (data key + payload shape differ).
+      if [[ "$dst_type" == "kubernetes.io/dockerconfigjson" && "$src_type" == "kubernetes.io/dockercfg" ]] ; then
+        key=".dockerconfigjson" ; other=".dockercfg"
+        decoded=$(jq -r '.data[".dockercfg"]' <<< "$object" | base64 -d | jq -c '{auths: .}' | base64 | tr -d '\n')
+      elif [[ "$dst_type" == "kubernetes.io/dockercfg" && "$src_type" == "kubernetes.io/dockerconfigjson" ]] ; then
+        key=".dockercfg" ; other=".dockerconfigjson"
+        decoded=$(jq -r '.data[".dockerconfigjson"]' <<< "$object" | base64 -d | jq -c '.auths' | base64 | tr -d '\n')
+      else
+        echo "secret-copier: SKIP $ns/$name non-convertible type mismatch ($src_type -> $dst_type)" >&2
+        return
+      fi
+
+      if [[ -z "$decoded" || "$decoded" == "null" ]] ; then
+        echo "secret-copier: SKIP $ns/$name conversion produced empty payload" >&2
+        return
+      fi
+
+      # Patch .data only: set the target-type key, drop the stale opposite key, leave .type untouched.
+      patch=$(jq -cn --arg k "$key" --arg o "$other" --arg v "$decoded" '{data: {($k): $v, ($o): null}}')
+      if kubectl -n "$ns" patch secret "$name" --type merge -p "$patch" >/dev/null ; then
+        echo "secret-copier: converted $ns/$name data ($src_type -> target type $dst_type; type preserved, data patched)"
+      else
+        echo "secret-copier: ERROR failed to patch $ns/$name on type mismatch ($src_type -> $dst_type)" >&2
+      fi
     }
 
     hook::config() {


### PR DESCRIPTION
## Problem

A Secret's `.type` is **immutable**. Docker pull secrets exist as two type variants written by different kubectl versions:

| type | data key | payload shape |
|------|----------|---------------|
| `kubernetes.io/dockercfg` (older kubectl) | `.dockercfg` | `{ "<registry>": {...} }` |
| `kubernetes.io/dockerconfigjson` (newer kubectl) | `.dockerconfigjson` | `{ "auths": { "<registry>": {...} } }` |

The copier piped the full source object (including `.type`) into `kubectl apply`. When a target secret already existed with the **other** type, `apply` failed on the immutable-field conflict, the copy silently broke, and stale/broken pull secrets caused a **production outage**.

Delete+recreate was deliberately rejected: a failed recreate leaves a namespace with no pull secret (bigger blast radius).

## Fix

Rewrite the shared `kubectl::replace_or_create` helper in all copy hooks to resolve each case explicitly and **never delete** the target:

- **target missing** → create (carries source type)
- **same type** → `apply` (only `.data` mutated); skip if `immutable`
- **type mismatch**, `dockercfg <-> dockerconfigjson` → **patch `.data` only**: convert payload to the target type's key/shape, drop the stale key, leave `.type` untouched; skip if `immutable`
- **any other type mismatch** → skip + warn (never guessed)

## Conversion (how it works, both directions)

The two formats differ by exactly one wrapper: the `auths` key. `dockercfg` equals the inner object of `dockerconfigjson.auths`, so conversion is just wrapping or unwrapping that key. The direction is chosen by the **target's existing type** (the type we must keep):

| source type | target type | jq op | writes key | prunes key |
|-------------|-------------|-------|------------|------------|
| `dockercfg` | `dockerconfigjson` | `{auths: .}` (wrap) | `.dockerconfigjson` | `.dockercfg` |
| `dockerconfigjson` | `dockercfg` | `.auths` (unwrap) | `.dockercfg` | `.dockerconfigjson` |

Per copy: read target type → base64-decode source data → wrap/unwrap → base64-encode → `kubectl patch --type merge` sets the target-type key + nulls the stale key, `.type` never sent.

Inner credential fields (`auth`, `username`, `password`, `email`) are carried through **verbatim** — only the top-level `auths` wrapper is added/removed. Lossless for us because every producer (AWS ECR `kubectl create secret docker-registry` and Terraform `kubernetes_secret`) emits `auths`-only payloads with nothing outside `auths` to drop.

## Observability

Every branch logs a `secret-copier:` line to shell-operator stdout (`created` / `updated` / `converted` / `SKIP` / `ERROR`) — the failure was previously silent until pods couldn't pull.

## Testing — verified on kind (arm64)

Extracted the actual `kubectl::replace_or_create` function from `values.yaml` and drove the copy path against a kind cluster. **Both conversion directions** plus create and same-type verified end-to-end.

| scenario | source → target | target type after | data key(s) | payload | log line |
|----------|-----------------|-------------------|-------------|---------|----------|
| **old → new** (wrap) | `dockercfg` → `dockerconfigjson` | `dockerconfigjson` (preserved) | `.dockerconfigjson` only | `{"auths":{...}}`, all fields intact | `converted` |
| **new → old** (unwrap) | `dockerconfigjson` → `dockercfg` | `dockercfg` (preserved) | `.dockercfg` only | inner object, all fields intact | `converted` |
| create | `dockercfg` → (no target) | created with source type | — | — | `created` |
| same-type | `dockercfg` → `dockercfg` | unchanged | `.dockercfg` | creds refreshed | `updated` |

Assertions in every mismatch case:
- target `.type` is **preserved** (never sent → no immutable-field conflict, no delete/recreate)
- the stale opposite key is pruned (only the target-type key remains)
- `auth` / `username` / `password` / `email` carried through verbatim (lossless)

Sample output (new → old):
```
BEFORE dst-b type=kubernetes.io/dockercfg
secret-copier: converted dst-b/sec-b data (kubernetes.io/dockerconfigjson -> target type kubernetes.io/dockercfg; type preserved, data patched)
AFTER  dst-b type=kubernetes.io/dockercfg keys=[".dockercfg"]
  payload={"reg.io":{"username":"AWS","password":"NEWSRC2","auth":"QVdTOk5FV1NSQzI=","email":"no@email.local"}}
```

Also validated: `helm lint`, `helm template`, `bash -n` on all four hooks.

## Also

- README rewritten to describe actual behavior (was stale flant `monitor-namespaces` / Helm 2 Tiller boilerplate).
- Chart bumped to `1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)