### PR TITLE
iac-operator: add Release spec-compression mutating webhook

### DIFF
--- a/iac-operator/Chart.yaml
+++ b/iac-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iac-operator
 description: A Helm chart for the Infrastructure as Code (IaC) Release Operator for Facets Cloud
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: "0.1.20"
 keywords:
   - iac

--- a/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
+++ b/iac-operator/templates/crds/iac.facets.cloud_releases.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .spec.environment.id
+    - jsonPath: .metadata.labels.iac\.facets\.cloud/environment-id
       name: Environment
       type: string
     - jsonPath: .status.currentPhase
@@ -54,6 +54,46 @@ spec:
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
+          compressedSpec:
+            description: |-
+              CompressedSpec holds the whole ReleaseSpec zstd-compressed, for objects
+              whose plain spec would exceed etcd's per-object size limit. It is
+              produced in-cluster by the compression mutating admission webhook — the
+              control plane always submits a plain Spec; the webhook rewrites large
+              objects into this form before they reach etcd. Mutually exclusive with
+              Spec.
+            properties:
+              algorithm:
+                description: Algorithm is the compression algorithm. Only "zstd" is
+                  supported.
+                enum:
+                - zstd
+                type: string
+              data:
+                description: |-
+                  Data is zstd(json(ReleaseSpec)). As a []byte on a custom resource it is
+                  stored base64-encoded in etcd by the Kubernetes JSON codec.
+                format: byte
+                type: string
+              digest:
+                description: |-
+                  Digest is the sha256 hex of the plaintext json(ReleaseSpec). It is
+                  verified against the decompressed bytes on read (integrity), and used
+                  as the spec-identity key for the immutability check.
+                type: string
+              uncompressedBytes:
+                description: |-
+                  UncompressedBytes is the plaintext byte length. Used for preallocation
+                  and as a decompression-bomb guard.
+                format: int64
+                minimum: 1
+                type: integer
+            required:
+            - algorithm
+            - data
+            - digest
+            - uncompressedBytes
+            type: object
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.
@@ -65,7 +105,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: ReleaseSpec defines the desired state of Release.
+            description: |-
+              Spec is the plain, readable desired state. In compressed mode this key
+              is absent from the stored object and CompressedSpec carries the spec
+              instead. Exactly one of Spec / CompressedSpec is populated on a stored
+              object. The operator inflates CompressedSpec into Spec in-place on read
+              (see InflateInPlace), so reconcile code always reads Spec.
             properties:
               artifactories:
                 description: Artifactories defines container registry configurations

--- a/iac-operator/templates/mutatingwebhook.yaml
+++ b/iac-operator/templates/mutatingwebhook.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.webhook.enabled .Values.webhook.compression.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "iac-operator.fullname" . }}-mutating-webhook
+  labels:
+    {{- include "iac-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "iac-operator.fullname" . }}-webhook-cert
+webhooks:
+# Compresses a large Release spec into spec.compressedSpec before it is
+# persisted, keeping the object under etcd's per-object size limit. Runs on
+# CREATE only; the spec is immutable so there is nothing to recompress on
+# UPDATE. Idempotent and reinvocation-safe.
+- name: compress.release.iac.facets.cloud
+  clientConfig:
+    service:
+      name: {{ include "iac-operator.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-iac-facets-cloud-v1-release
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  reinvocationPolicy: IfNeeded
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - iac.facets.cloud
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - releases
+    scope: "*"
+{{- end }}

--- a/iac-operator/values.yaml
+++ b/iac-operator/values.yaml
@@ -97,6 +97,12 @@ webhook:
   service:
     type: ClusterIP
     annotations: {}
+  # Spec-compression mutating webhook: rewrites large Release specs into
+  # spec.compressedSpec (zstd) before they reach etcd, keeping objects under
+  # the per-object size limit. Enabled by default; disable to store specs
+  # plain (only safe if all blueprints stay well under the etcd limit).
+  compression:
+    enabled: true
 
 # API configuration for custom endpoints (approve, decline, status)
 api:


### PR DESCRIPTION
Deploys the mutating admission webhook that pairs with the operator's Release spec-compression feature (iac-generator#104, closes iac-generator#103).

## What
Large `Release` specs exceed etcd's 1.5 MiB per-object limit. The operator now compresses them (zstd) server-side before they reach etcd. This chart change ships the webhook config + updated CRD needed to run it.

## Changes
- **`templates/mutatingwebhook.yaml`** (new): `MutatingWebhookConfiguration` `compress.release.iac.facets.cloud` — CREATE-only on `releases`, cert-manager CA injection, shared `webhook-service`, `failurePolicy` from values, `reinvocationPolicy: IfNeeded`.
- **`values.yaml`**: `webhook.compression.enabled` (default `true`) to toggle it.
- **`crds/iac.facets.cloud_releases.yaml`**: synced regenerated CRD — top-level `compressedSpec`, `spec` now optional, `Environment` printcolumn reads the `iac.facets.cloud/environment-id` label mirror.
- **`Chart.yaml`**: `0.1.22` → `0.1.23`.

## Compatibility
- Requires an iac-generator operator image that includes the compression webhook handler (iac-generator#104). Deploy that image at or before this chart.
- Reuses the existing webhook service + cert-manager certificate — no new infra.
- Backward compatible: plain (uncompressed) Releases are unaffected; set `webhook.compression.enabled=false` to disable.

Verified: `helm lint` clean; both toggles (`webhook.enabled`, `webhook.compression.enabled`) render/suppress correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)