### PR TITLE
fix: move kube-rbac-proxy off dead gcr.io/kubebuilder registry

### DIFF
--- a/database-operator/Chart.yaml
+++ b/database-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: database-operator
 description: A Helm chart for database operator
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: v1.2.0
 home: https://facets-cloud.github.io
 sources:

--- a/database-operator/values.yaml
+++ b/database-operator/values.yaml
@@ -11,8 +11,8 @@ controllerManager:
         drop:
         - ALL
     image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.13.1
+      repository: quay.io/brancz/kube-rbac-proxy
+      tag: v0.19.0
     resources:
       limits:
         cpu: 500m

--- a/facets-uptime-monitoring/Chart.yaml
+++ b/facets-uptime-monitoring/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"

--- a/facets-uptime-monitoring/templates/manager-rbac.yaml
+++ b/facets-uptime-monitoring/templates/manager-rbac.yaml
@@ -187,6 +187,32 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - uptime.facets.cloud
+  resources:
+  - uptimechecks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - uptime.facets.cloud
+  resources:
+  - uptimechecks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - uptime.facets.cloud
+  resources:
+  - uptimechecks/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/facets-uptime-monitoring/templates/uptimecheck-crd.yaml
+++ b/facets-uptime-monitoring/templates/uptimecheck-crd.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: uptimechecks.uptime.facets.cloud
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
+spec:
+  group: uptime.facets.cloud
+  names:
+    kind: UptimeCheck
+    listKind: UptimeCheckList
+    plural: uptimechecks
+    shortNames:
+    - uptimecheck
+    singular: uptimecheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.checkType
+      name: CheckType
+      type: string
+    - jsonPath: .status.ok
+      name: Ok
+      type: string
+    - jsonPath: .status.lastRunTime
+      name: LastRunTime
+      type: string
+    - jsonPath: .status.nextRuntime
+      name: NextRuntime
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UptimeCheck is the Schema for the uptimechecks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UptimeCheckSpec defines the desired state of UptimeCheck
+            properties:
+              checkType:
+                enum:
+                - http
+                - mongo
+                - redis
+                - tcp
+                - ssl
+                minLength: 1
+                type: string
+              count:
+                minLength: 1
+                type: string
+              expectedResponse:
+                minLength: 1
+                type: string
+              expectedStatusCode:
+                minLength: 1
+                type: string
+              passingPercent:
+                minLength: 1
+                type: string
+              requestBody:
+                minLength: 1
+                type: string
+              requestType:
+                minLength: 1
+                type: string
+              runInterval:
+                minLength: 1
+                pattern: (\d+(ns|us|µs|ms|s|m|h))+
+                type: string
+              seconds:
+                minLength: 1
+                type: string
+              timeout:
+                minLength: 1
+                type: string
+              url:
+                minLength: 1
+                type: string
+            required:
+            - checkType
+            - runInterval
+            - timeout
+            - url
+            type: object
+          status:
+            description: UptimeCheckStatus defines the observed state of UptimeCheck
+            properties:
+              errors:
+                type: string
+              lastRunTime:
+                type: string
+              nextRuntime:
+                type: string
+              ok:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/facets-uptime-monitoring/values.yaml
+++ b/facets-uptime-monitoring/values.yaml
@@ -11,8 +11,8 @@ controllerManager:
         drop:
         - ALL
     image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.13.1
+      repository: quay.io/brancz/kube-rbac-proxy
+      tag: v0.19.0
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
## Problem

Google shut down the `gcr.io/kubebuilder` registry and deleted its images. Two charts here still default their `kube-rbac-proxy` sidecar to `gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1`:

- `facets-uptime-monitoring`
- `database-operator`

Any node that no longer has the image cached fails the pull with `NotFound` → pod stuck `1/2 Ready` in `ImagePullBackOff`, metrics endpoint down. Observed live on `fcp/mplpro` (facets-uptime-monitoring, broken 66+ days). Companion module-level override for capillary-cloud-tf: Facets-cloud/facets-iac#2137.

## Changes

- Both charts: default the sidecar image to `quay.io/brancz/kube-rbac-proxy:v0.19.0` — the image's current home, and the same version facets-iac already uses for `wireguard_operator` (facets-iac #1706).
- **`facets-uptime-monitoring`: reconciled master with the published 0.2.0 package.** The gh-pages 0.2.0 tarball contains `templates/uptimecheck-crd.yaml` and the `uptime.facets.cloud` RBAC rules, but those were never committed to master (Chart.yaml here was still 0.1.0). Ported them in so packaging 0.2.1 from master is a strict superset of what's deployed. Bumped chart to **0.2.1**, appVersion 0.2.0.
- `database-operator`: master already matched the published 1.2.0; bumped chart to **1.2.1**.

Both charts pass `helm lint` and `helm template`.

## Note for maintainers

The chart copy in `Facets-cloud/facets-uptime-monitoring` (`chart/`) has diverged much further (adds httpcheck/mongocheck/redischeck/sql/ssl/tcp/rabbitmq CRDs) than either this repo or the published 0.2.0 — worth deciding which copy is canonical and reconciling; this PR deliberately only brings master up to the published state plus the image fix.

After merge, the `Package and Publish Helm Chart` workflow (workflow_dispatch) needs a manual run to publish 0.2.1 / 1.2.1 to gh-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)